### PR TITLE
Fixes #12: Could not find artifact net.sf.ehcache:ehcache-terracotta:jar...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lucene.version>4.10.1</lucene.version>
-        <ehcache.version>2.6.2</ehcache.version>
+        <ehcache.version>2.9.0</ehcache.version>
         <hadoop.version>1.2.1</hadoop.version>
         <log4j.version>1.2.17</log4j.version>
         <rhino.version>1.7R4</rhino.version>
@@ -98,7 +98,6 @@
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache</artifactId>
             <version>${ehcache.version}</version>
-            <type>pom</type>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
...:2.6.2 in central

- pom.xml: EHCache version updated to 2.9.0 and changed to type jar.