### PR TITLE
If different term after the requested term was found, show that.

### DIFF
--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -3479,7 +3479,8 @@ public class Luke extends Thinlet implements ClipboardOwner {
             putProperty(fCombo, "te", te);
             putProperty(fCombo, "teField", fld);
             status = te.seekCeil(new BytesRef(text));
-            if (status.equals(SeekStatus.FOUND)) {
+            if (status.equals(SeekStatus.FOUND) || status.equals(SeekStatus.NOT_FOUND)) {
+              // precise term or different term after the requested term was found.
               rawTerm = te.term();
             } else {
               rawTerm = null;


### PR DESCRIPTION
Following to the message 'Hint: enter a substring and press Next to start at the nearest term', in 'Browse by term' feature in Documents tab, this if statement might be modified as below.
(Under current implementation, Luke proceeds to next field soon if the exact term was not found.) 

According to Lucene API reference, TermsEnum#seekCeil() returns SeekStatus.NOT_FOUND if a different term was found after the requested term.
http://lucene.apache.org/core/4_10_3/core/org/apache/lucene/index/TermsEnum.SeekStatus.html

I know this is a subtle point, but I feel it's good for usability. Hope it makes sense.
Thanks.

