### PR TITLE
Elasticsearch support and Shade plugin for assembly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,9 @@
         <hadoop.version>1.2.1</hadoop.version>
         <log4j.version>1.2.17</log4j.version>
         <rhino.version>1.7R4</rhino.version>
+        <elasticsearch.version>1.5.0</elasticsearch.version>
 
-        <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
+        <maven-shade-plugin.version>2.3</maven-shade-plugin.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
@@ -66,6 +67,14 @@
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
             <version>${lucene.version}</version>
+        </dependency>
+
+        <!-- Elasticsearch -->
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
         </dependency>
 
         <!-- SOLR -->
@@ -195,31 +204,36 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <artifactId>maven-shade-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>
-                <version>${maven-assembly-plugin.version}</version>
+                <version>${maven-shade-plugin.version}</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.getopt.luke.Luke</mainClass>
-                        </manifest>
-                    </archive>
-					<finalName>${project.artifactId}-with-deps</finalName>
-					<appendAssemblyId>false</appendAssemblyId>
+                    <finalName>${project.artifactId}-with-deps</finalName>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>make-assembly</id>
-                        <!-- this is used for inheritance merges -->
                         <phase>package</phase>
-                        <!-- append to the packaging phase. -->
                         <goals>
-                            <goal>single</goal>
-                            <!-- goals == mojos -->
+                            <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.getopt.luke.Luke</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Hi @DmitryKey 
The reason I replaced assembly plugin with shade, because it provide out of the box support for merging META-INF/services file - that's required for Elasticsearch support.