### PR TITLE
Lucene 5x support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <lucene.version>5.1.0</lucene.version>
+        <lucene.version>5.2.0</lucene.version>
         <ehcache.version>2.9.0</ehcache.version>
         <hadoop.version>1.2.1</hadoop.version>
         <log4j.version>1.2.17</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <lucene.version>4.10.4</lucene.version>
+        <lucene.version>5.1.0</lucene.version>
         <ehcache.version>2.9.0</ehcache.version>
         <hadoop.version>1.2.1</hadoop.version>
         <log4j.version>1.2.17</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,13 @@
 
         <!-- Elasticsearch -->
 
+        <!-- TODO: uncomment following dependencies at future Elasticsearch release (supporting Lucene 5x)
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>
         </dependency>
+        -->
 
         <!-- SOLR -->
 

--- a/src/main/java/org/apache/lucene/index/IndexGate.java
+++ b/src/main/java/org/apache/lucene/index/IndexGate.java
@@ -191,12 +191,12 @@ public class IndexGate {
         try {
           int indexFormat = in.readInt();
           if (indexFormat == CodecUtil.CODEC_MAGIC) {
-            res.genericName = "Lucene 4.x";
+            res.genericName = "Lucene 5.x";
             res.capabilities = "flexible, codec-specific";
-            int actualVersion = SegmentInfos.VERSION_40;
+            int actualVersion = SegmentInfos.VERSION_51;
             try {
               actualVersion = CodecUtil.checkHeaderNoMagic(in, "segments", SegmentInfos.VERSION_40, Integer.MAX_VALUE);
-              if (actualVersion > SegmentInfos.VERSION_49) {
+              if (actualVersion > SegmentInfos.VERSION_51) {
                 res.capabilities += " (WARNING: newer version of Lucene than this tool)";
                 System.out.println("WARNING: newer version of Lucene than this tool supports");
               }
@@ -204,8 +204,32 @@ public class IndexGate {
               e.printStackTrace();
               res.capabilities += " (error reading: " + e.getMessage() + ")";
             }
-            res.genericName = "Lucene 4." + actualVersion;
-            res.version = "4." + actualVersion;
+            switch(actualVersion) {
+              case SegmentInfos.VERSION_40:
+                res.genericName = "Lucene 4.0 or later";
+                res.version = "4.0 or lager";
+                break;
+              case SegmentInfos.VERSION_46:
+                res.genericName = "Lucene 4.6 or later";
+                res.version = "4.6 or lager";
+                break;
+              case SegmentInfos.VERSION_48:
+                res.genericName = "Lucene 4.8 or later";
+                res.version = "4.8 or lager";
+                break;
+              case SegmentInfos.VERSION_49:
+                res.genericName = "Lucene 4.9 or later";
+                res.version = "4.9 or lager";
+                break;
+              case SegmentInfos.VERSION_50:
+                res.genericName = "Lucene 5.0";
+                res.version = "5.0";
+                break;
+              case SegmentInfos.VERSION_51:
+                res.genericName = "Lucene 5.1 or later";
+                res.version = "5.1 or later";
+                break;
+            }
           } else {
             res.genericName = "Lucene 3.x or prior";
             detectOldFormats(res, indexFormat);

--- a/src/main/java/org/apache/lucene/index/IndexGate.java
+++ b/src/main/java/org/apache/lucene/index/IndexGate.java
@@ -71,9 +71,9 @@ public class IndexGate {
   public static final int FORMAT_PRE_4 = -12;
 
   static {
-    knownExtensions.put(IndexFileNames.COMPOUND_FILE_EXTENSION, "compound file with various index data");
-    knownExtensions.put(IndexFileNames.COMPOUND_FILE_ENTRIES_EXTENSION, "compound file entries list");
-    knownExtensions.put(IndexFileNames.GEN_EXTENSION, "generation number - global file");
+    //knownExtensions.put(IndexFileNames.COMPOUND_FILE_EXTENSION, "compound file with various index data");
+    //knownExtensions.put(IndexFileNames.COMPOUND_FILE_ENTRIES_EXTENSION, "compound file entries list");
+    //knownExtensions.put(IndexFileNames.GEN_EXTENSION, "generation number - global file");
     knownExtensions.put(IndexFileNames.SEGMENTS, "per-commit list of segments and user data");
   }
   
@@ -223,8 +223,9 @@ public class IndexGate {
   }
   
   public static boolean preferCompoundFormat(Directory dir) throws Exception {
-    SegmentInfos infos = new SegmentInfos();
-    infos.read(dir);
+    // SegmentInfos infos = new SegmentInfos();
+    // infos.read(dir);
+    SegmentInfos infos = SegmentInfos.readLatestCommit(dir);
     int compound = 0, nonCompound = 0;
     for (int i = 0; i < infos.size(); i++) {
       if (infos.info(i).info.getUseCompoundFile()) {
@@ -265,9 +266,11 @@ public class IndexGate {
     for (IndexCommit ic : commits) {
       known.addAll(ic.getFileNames());
     }
-    if (dir.fileExists(IndexFileNames.SEGMENTS_GEN)) {
-      known.add(IndexFileNames.SEGMENTS_GEN);
+    /* FIXME: Directory#fileExists was removed since lucene 5.1.0
+    if (dir.fileExists(IndexFileNames.OLD_SEGMENTS_GEN)) {
+      known.add(IndexFileNames.OLD_SEGMENTS_GEN);
     }
+    */
     List<String> names = new ArrayList<String>(known);
     Collections.sort(names);
     return names;

--- a/src/main/java/org/getopt/luke/AccessibleHitCollector.java
+++ b/src/main/java/org/getopt/luke/AccessibleHitCollector.java
@@ -3,7 +3,7 @@ package org.getopt.luke;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Scorer;
 
-public abstract class AccessibleHitCollector extends Collector {
+public abstract class AccessibleHitCollector implements Collector {
   protected Scorer scorer;
   protected boolean shouldScore;
   protected int docBase;

--- a/src/main/java/org/getopt/luke/AccessibleTopHitCollector.java
+++ b/src/main/java/org/getopt/luke/AccessibleTopHitCollector.java
@@ -2,8 +2,9 @@ package org.getopt.luke;
 
 import java.io.IOException;
 
-import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopScoreDocCollector;
@@ -14,9 +15,9 @@ public class AccessibleTopHitCollector extends AccessibleHitCollector {
   private int size;
   
   public AccessibleTopHitCollector(int size, boolean outOfOrder, boolean shouldScore) {
-    tdc = TopScoreDocCollector.create(size, outOfOrder);
-    this.shouldScore = shouldScore;
-    this.outOfOrder = outOfOrder;
+    tdc = TopScoreDocCollector.create(size);
+    //this.shouldScore = shouldScore;
+    //this.outOfOrder = outOfOrder;
     this.size = size;
   }
 
@@ -41,35 +42,48 @@ public class AccessibleTopHitCollector extends AccessibleHitCollector {
     return tdc.getTotalHits();
   }
 
-  @Override
-  public boolean acceptsDocsOutOfOrder() {
-    return tdc.acceptsDocsOutOfOrder();
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public boolean acceptsDocsOutOfOrder() {
+  //  return tdc.acceptsDocsOutOfOrder();
+  //}
 
-  @Override
-  public void collect(int doc) throws IOException {
-    tdc.collect(doc);
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void collect(int doc) throws IOException {
+  //  tdc.collect(doc);
+  //}
 
-  @Override
-  public void setNextReader(AtomicReaderContext context) throws IOException {
-    this.docBase = context.docBase;
-    tdc.setNextReader(context);
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void setNextReader(AtomicReaderContext context) throws IOException {
+  //  this.docBase = context.docBase;
+  //  tdc.setNextReader(context);
+  //}
 
-  @Override
-  public void setScorer(Scorer scorer) throws IOException {
-    if (shouldScore) {
-      tdc.setScorer(scorer);
-    } else {
-      tdc.setScorer(NoScoringScorer.INSTANCE);
-    }
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void setScorer(Scorer scorer) throws IOException {
+  //  if (shouldScore) {
+  //    tdc.setScorer(scorer);
+  //  } else {
+  //    tdc.setScorer(NoScoringScorer.INSTANCE);
+  //  }
+  //}
 
   @Override
   public void reset() {
-    tdc = TopScoreDocCollector.create(size, outOfOrder);
+    tdc = TopScoreDocCollector.create(size);
     topDocs = null;
   }
 
+  @Override
+  public LeafCollector getLeafCollector(LeafReaderContext leafReaderContext) throws IOException {
+    return tdc.getLeafCollector(leafReaderContext);
+  }
+
+  @Override
+  public boolean needsScores() {
+    return tdc.needsScores();
+  }
 }

--- a/src/main/java/org/getopt/luke/AccessibleTopHitCollector.java
+++ b/src/main/java/org/getopt/luke/AccessibleTopHitCollector.java
@@ -14,10 +14,8 @@ public class AccessibleTopHitCollector extends AccessibleHitCollector {
   private TopDocs topDocs = null;
   private int size;
   
-  public AccessibleTopHitCollector(int size, boolean outOfOrder, boolean shouldScore) {
+  public AccessibleTopHitCollector(int size) {
     tdc = TopScoreDocCollector.create(size);
-    //this.shouldScore = shouldScore;
-    //this.outOfOrder = outOfOrder;
     this.size = size;
   }
 
@@ -41,35 +39,6 @@ public class AccessibleTopHitCollector extends AccessibleHitCollector {
   public int getTotalHits() {
     return tdc.getTotalHits();
   }
-
-  // obsoleted since 5.x
-  //@Override
-  //public boolean acceptsDocsOutOfOrder() {
-  //  return tdc.acceptsDocsOutOfOrder();
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public void collect(int doc) throws IOException {
-  //  tdc.collect(doc);
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public void setNextReader(AtomicReaderContext context) throws IOException {
-  //  this.docBase = context.docBase;
-  //  tdc.setNextReader(context);
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public void setScorer(Scorer scorer) throws IOException {
-  //  if (shouldScore) {
-  //    tdc.setScorer(scorer);
-  //  } else {
-  //    tdc.setScorer(NoScoringScorer.INSTANCE);
-  //  }
-  //}
 
   @Override
   public void reset() {

--- a/src/main/java/org/getopt/luke/AllHitsCollector.java
+++ b/src/main/java/org/getopt/luke/AllHitsCollector.java
@@ -14,25 +14,8 @@ class AllHitsCollector extends AccessibleHitCollector {
   private ArrayList<AllHit> hits = new ArrayList<AllHit>();
   
   public AllHitsCollector() {
-    //this.outOfOrder = outOfOrder;
-    //this.shouldScore = shouldScore;
   }
 
-  /*
-  public void collect(int doc) {
-    float score = 1.0f;
-    if (shouldScore) {
-      try {
-        score = scorer.score();
-      } catch (IOException e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
-      }
-    }
-    hits.add(new AllHit(docBase + doc, score));
-  }
-  */
-  
   public int getTotalHits() {
     return hits.size();
   }
@@ -86,24 +69,6 @@ class AllHitsCollector extends AccessibleHitCollector {
       this.score = score;
     }
   }
-
-  // obsoleted since 5.x
-  // @Override
-  // public boolean acceptsDocsOutOfOrder() {
-  //  return outOfOrder;
-  // }
-
-  // obsoleted since 5.x
-  //@Override
-  //public void setNextReader(AtomicReaderContext context) throws IOException {
-  //  this.docBase = context.docBase;
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public void setScorer(Scorer scorer) throws IOException {
-  //  this.scorer = scorer;
-  //}
 
   @Override
   public void reset() {

--- a/src/main/java/org/getopt/luke/AllHitsCollector.java
+++ b/src/main/java/org/getopt/luke/AllHitsCollector.java
@@ -6,8 +6,9 @@ package org.getopt.luke;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorer;
 
 class AllHitsCollector extends AccessibleHitCollector {
@@ -43,6 +44,17 @@ class AllHitsCollector extends AccessibleHitCollector {
     return ((AllHitsCollector.AllHit)hits.get(i)).score;
   }
 
+  @Override
+  public LeafCollector getLeafCollector(LeafReaderContext leafReaderContext) throws IOException {
+    //this.docBase = leafReaderContext.docBase;
+    return super.getLeafCollector(leafReaderContext);
+  }
+
+  @Override
+  public boolean needsScores() {
+    return false;
+  }
+
   private static class AllHit {
     public int docId;
     public float score;
@@ -53,20 +65,23 @@ class AllHitsCollector extends AccessibleHitCollector {
     }
   }
 
-  @Override
-  public boolean acceptsDocsOutOfOrder() {
-    return outOfOrder;
-  }
+  // obsoleted since 5.x
+  // @Override
+  // public boolean acceptsDocsOutOfOrder() {
+  //  return outOfOrder;
+  // }
 
-  @Override
-  public void setNextReader(AtomicReaderContext context) throws IOException {
-    this.docBase = context.docBase;
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void setNextReader(AtomicReaderContext context) throws IOException {
+  //  this.docBase = context.docBase;
+  //}
 
-  @Override
-  public void setScorer(Scorer scorer) throws IOException {
-    this.scorer = scorer;
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void setScorer(Scorer scorer) throws IOException {
+  //  this.scorer = scorer;
+  //}
 
   @Override
   public void reset() {

--- a/src/main/java/org/getopt/luke/CountLimitedHitCollector.java
+++ b/src/main/java/org/getopt/luke/CountLimitedHitCollector.java
@@ -2,8 +2,9 @@ package org.getopt.luke;
 
 import java.io.IOException;
 
-import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopScoreDocCollector;
@@ -17,10 +18,10 @@ public class CountLimitedHitCollector extends LimitedHitCollector {
   
   public CountLimitedHitCollector(int maxSize, boolean outOfOrder, boolean shouldScore) {
     this.maxSize = maxSize;
-    this.outOfOrder = outOfOrder;
-    this.shouldScore = shouldScore;
+    //this.outOfOrder = outOfOrder;
+    //this.shouldScore = shouldScore;
     count = 0;
-    tdc = TopScoreDocCollector.create(maxSize, outOfOrder);
+    tdc = TopScoreDocCollector.create(maxSize);
   }
 
   @Override
@@ -36,17 +37,17 @@ public class CountLimitedHitCollector extends LimitedHitCollector {
   /* (non-Javadoc)
    * @see org.getopt.luke.AllHitsCollector#collect(int, float)
    */
-  @Override
-  public void collect(int doc) throws IOException {
-    count++;
-    if (count > maxSize) {
-      count--;
-      throw new LimitedException(TYPE_SIZE, maxSize, count, lastDoc);
-    }
-    lastDoc = docBase + doc;
-    
-    tdc.collect(doc);
-  }
+  //@Override
+  //public void collect(int doc) throws IOException {
+  //  count++;
+  //  if (count > maxSize) {
+  //    count--;
+  //    throw new LimitedException(TYPE_SIZE, maxSize, count, lastDoc);
+  //  }
+  //  lastDoc = docBase + doc;
+  //
+  //  tdc.collect(doc);
+  //}
 
   /* (non-Javadoc)
    * @see org.getopt.luke.AccessibleHitCollector#getDocId(int)
@@ -78,31 +79,44 @@ public class CountLimitedHitCollector extends LimitedHitCollector {
     return count;
   }
 
-  @Override
-  public boolean acceptsDocsOutOfOrder() {
-    return tdc.acceptsDocsOutOfOrder();
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public boolean acceptsDocsOutOfOrder() {
+  //  return tdc.acceptsDocsOutOfOrder();
+  //}
 
-  @Override
-  public void setNextReader(AtomicReaderContext context) throws IOException {
-    this.docBase = context.docBase;
-    tdc.setNextReader(context);
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void setNextReader(AtomicReaderContext context) throws IOException {
+  //  this.docBase = context.docBase;
+  //  tdc.setNextReader(context);
+  //}
 
-  @Override
-  public void setScorer(Scorer scorer) throws IOException {
-    if (shouldScore) {
-      tdc.setScorer(scorer);
-    } else {
-      tdc.setScorer(NoScoringScorer.INSTANCE);
-    }
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void setScorer(Scorer scorer) throws IOException {
+  //  if (shouldScore) {
+  //    tdc.setScorer(scorer);
+  //  } else {
+  //    tdc.setScorer(NoScoringScorer.INSTANCE);
+  //  }
+  //}
 
   @Override
   public void reset() {
     count = 0;
     lastDoc = 0;
     topDocs = null;
-    tdc = TopScoreDocCollector.create(maxSize, outOfOrder);
+    tdc = TopScoreDocCollector.create(maxSize);
+  }
+
+  @Override
+  public LeafCollector getLeafCollector(LeafReaderContext leafReaderContext) throws IOException {
+    return tdc.getLeafCollector(leafReaderContext);
+  }
+
+  @Override
+  public boolean needsScores() {
+    return tdc.needsScores();
   }
 }

--- a/src/main/java/org/getopt/luke/CountLimitedHitCollector.java
+++ b/src/main/java/org/getopt/luke/CountLimitedHitCollector.java
@@ -32,21 +32,6 @@ public class CountLimitedHitCollector extends LimitedHitCollector {
   }
 
   /* (non-Javadoc)
-   * @see org.getopt.luke.AllHitsCollector#collect(int, float)
-   */
-  //@Override
-  //public void collect(int doc) throws IOException {
-  //  count++;
-  //  if (count > maxSize) {
-  //    count--;
-  //    throw new LimitedException(TYPE_SIZE, maxSize, count, lastDoc);
-  //  }
-  //  lastDoc = docBase + doc;
-  //
-  //  tdc.collect(doc);
-  //}
-
-  /* (non-Javadoc)
    * @see org.getopt.luke.AccessibleHitCollector#getDocId(int)
    */
   @Override
@@ -75,29 +60,6 @@ public class CountLimitedHitCollector extends LimitedHitCollector {
   public int getTotalHits() {
     return count;
   }
-
-  // obsoleted since 5.x
-  //@Override
-  //public boolean acceptsDocsOutOfOrder() {
-  //  return tdc.acceptsDocsOutOfOrder();
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public void setNextReader(AtomicReaderContext context) throws IOException {
-  //  this.docBase = context.docBase;
-  //  tdc.setNextReader(context);
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public void setScorer(Scorer scorer) throws IOException {
-  //  if (shouldScore) {
-  //    tdc.setScorer(scorer);
-  //  } else {
-  //    tdc.setScorer(NoScoringScorer.INSTANCE);
-  //  }
-  //}
 
   @Override
   public void reset() {

--- a/src/main/java/org/getopt/luke/DocReconstructor.java
+++ b/src/main/java/org/getopt/luke/DocReconstructor.java
@@ -67,7 +67,7 @@ public class DocReconstructor extends Observable {
       while (fe.hasNext()) {
           String fld = fe.next();
         Terms t = fields.terms(fld);
-        TermsEnum te = t.iterator(null);
+        TermsEnum te = t.iterator();
         while (te.next() != null) {
           numTerms++;
         }
@@ -112,12 +112,12 @@ public class DocReconstructor extends Observable {
     for (int i = 0; i < fieldNames.length; i++) {
       Terms tvf = reader.getTermVector(docNum, fieldNames[i]);
       if (tvf != null) { // has vectors for this field
-        te = tvf.iterator(te);
+        te = tvf.iterator();
         progress.message = "Checking term vectors for '" + fieldNames[i] + "' ...";
         progress.curValue = i;
         setChanged();
         notifyObservers(progress);
-        List<IntPair> vectors = TermVectorMapper.map(tvf, te, false, true);
+        List<IntPair> vectors = TermVectorMapper.map(tvf, false, true);
         if (vectors != null) {
           GrowableStringArray gsa = res.getReconstructedFields().get(fieldNames[i]);
           if (gsa == null) {
@@ -147,7 +147,7 @@ public class DocReconstructor extends Observable {
       if (terms == null) { // no terms in this field
         continue;
       }
-      te = terms.iterator(te);
+      te = terms.iterator();
       BytesRef bytesRef;
       while ((bytesRef=te.next()) != null) {
         // first use bytesRef to extract the indexed term value

--- a/src/main/java/org/getopt/luke/DocReconstructor.java
+++ b/src/main/java/org/getopt/luke/DocReconstructor.java
@@ -21,7 +21,7 @@ import java.util.*;
 public class DocReconstructor extends Observable {
   private ProgressNotification progress = new ProgressNotification();
   private String[] fieldNames = null;
-  private AtomicReader reader = null;
+  private LeafReader reader = null;
   private int numTerms;
   private Bits live;
   
@@ -49,8 +49,8 @@ public class DocReconstructor extends Observable {
     }
     if (reader instanceof CompositeReader) {
       this.reader = SlowCompositeReaderWrapper.wrap(reader);
-    } else if (reader instanceof AtomicReader) {
-      this.reader = (AtomicReader)reader;
+    } else if (reader instanceof LeafReader) {
+      this.reader = (LeafReader)reader;
     } else {
       throw new Exception("Unsupported IndexReader class " + reader.getClass().getName());
     }

--- a/src/main/java/org/getopt/luke/HighFreqTerms.java
+++ b/src/main/java/org/getopt/luke/HighFreqTerms.java
@@ -125,7 +125,7 @@ public class HighFreqTerms {
       for (String field : fieldNames) {
         Terms terms = fields.terms(field);
         if (terms != null) {
-          te = terms.iterator(te);
+          te = terms.iterator();
           fillQueue(te, tiq, field);
         }
       }
@@ -141,7 +141,7 @@ public class HighFreqTerms {
           String field = fieldIterator.next();
         Terms terms = fields.terms(field);
         if (terms != null) {
-          te = terms.iterator(te);
+          te = terms.iterator();
           fillQueue(te, tiq, field);
         }
       }
@@ -200,7 +200,7 @@ public class HighFreqTerms {
   private static long totalTermFreq(IndexReader r, String field, BytesRef text) throws IOException {
       final Terms terms = MultiFields.getTerms(r, field);
       if (terms != null) {
-        final TermsEnum termsEnum = terms.iterator(null);
+        final TermsEnum termsEnum = terms.iterator();
         if (termsEnum.seekExact(text)) {
           return termsEnum.totalTermFreq();
         }

--- a/src/main/java/org/getopt/luke/HighFreqTerms.java
+++ b/src/main/java/org/getopt/luke/HighFreqTerms.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -59,7 +60,7 @@ public class HighFreqTerms {
     }     
 
     if (args.length > 0) {
-      dir = FSDirectory.open(new File(args[0]));
+      dir = FSDirectory.open(FileSystems.getDefault().getPath(args[0]));
     }
    
     for (int i = 1; i < args.length; i++) {
@@ -210,8 +211,9 @@ public class HighFreqTerms {
   public static void fillQueue(TermsEnum termsEnum, TermStatsQueue tiq, String field) throws Exception {
   BytesRef term;
   while ((term = termsEnum.next()) != null) {
-      BytesRef r = new BytesRef();
-      r.copyBytes(term);
+      //BytesRef r = new BytesRef();
+      //r.copyBytes(term);
+      BytesRef r = BytesRef.deepCopyOf(term);
       tiq.insertWithOverflow(new TermStats(field, r, termsEnum.docFreq()));
     }
   }

--- a/src/main/java/org/getopt/luke/IndexInfo.java
+++ b/src/main/java/org/getopt/luke/IndexInfo.java
@@ -61,7 +61,7 @@ public class IndexInfo {
       ftc.fieldname = fld;
       Terms terms = fields.terms(fld);
       if (terms != null) { // count terms
-        te = terms.iterator(te);
+        te = terms.iterator();
         while (te.next() != null) {
           ftc.termCount++;
           numTerms++;

--- a/src/main/java/org/getopt/luke/IntervalLimitedCollector.java
+++ b/src/main/java/org/getopt/luke/IntervalLimitedCollector.java
@@ -13,10 +13,8 @@ public class IntervalLimitedCollector extends LimitedHitCollector {
   private TimeLimitingCollector thc;
   
   
-  public IntervalLimitedCollector(int maxTime, boolean outOfOrder, boolean shouldScore) {
+  public IntervalLimitedCollector(int maxTime) {
     this.maxTime = maxTime;
-    //this.outOfOrder = outOfOrder;
-    //this.shouldScore = shouldScore;
     tdc = TopScoreDocCollector.create(1000);
     thc = new TimeLimitingCollector(tdc, TimeLimitingCollector.getGlobalCounter(), maxTime);
   }
@@ -60,41 +58,6 @@ public class IntervalLimitedCollector extends LimitedHitCollector {
   public int getTotalHits() {
     return tdc.getTotalHits();
   }
-
-  // obsoleted since 5.x
-  //@Override
-  //public void collect(int docNum) throws IOException {
-  //  try {
-  //    thc.collect(docNum);
-  //  } catch (TimeExceededException tee) {
-      // re-throw
-  //    throw new LimitedException(TYPE_TIME, maxTime, tee.getTimeElapsed(), tee.getLastDocCollected());
-  //  }
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public boolean acceptsDocsOutOfOrder() {
-  //  return outOfOrder;
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public void setNextReader(AtomicReaderContext context) throws IOException {
-  //  this.docBase = context.docBase;
-  //  thc.setNextReader(context);
-  //}
-
-  // obsoleted since 5.x
-  //@Override
-  //public void setScorer(Scorer scorer) throws IOException {
-  //  this.scorer = scorer;
-  //  if (shouldScore) {
-  //    thc.setScorer(scorer);
-  //  } else {
-  //    thc.setScorer(NoScoringScorer.INSTANCE);
-  //  }
-  //}
 
   @Override
   public void reset() {

--- a/src/main/java/org/getopt/luke/IntervalLimitedCollector.java
+++ b/src/main/java/org/getopt/luke/IntervalLimitedCollector.java
@@ -2,13 +2,8 @@ package org.getopt.luke;
 
 import java.io.IOException;
 
-import org.apache.lucene.index.AtomicReaderContext;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.TimeLimitingCollector;
-import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopScoreDocCollector;
-import org.apache.lucene.search.TimeLimitingCollector.TimeExceededException;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.*;
 
 public class IntervalLimitedCollector extends LimitedHitCollector {
   private long maxTime;
@@ -20,9 +15,9 @@ public class IntervalLimitedCollector extends LimitedHitCollector {
   
   public IntervalLimitedCollector(int maxTime, boolean outOfOrder, boolean shouldScore) {
     this.maxTime = maxTime;
-    this.outOfOrder = outOfOrder;
-    this.shouldScore = shouldScore;
-    tdc = TopScoreDocCollector.create(1000, outOfOrder);
+    //this.outOfOrder = outOfOrder;
+    //this.shouldScore = shouldScore;
+    tdc = TopScoreDocCollector.create(1000);
     thc = new TimeLimitingCollector(tdc, TimeLimitingCollector.getGlobalCounter(), maxTime);
   }
 
@@ -66,41 +61,55 @@ public class IntervalLimitedCollector extends LimitedHitCollector {
     return tdc.getTotalHits();
   }
 
-  @Override
-  public void collect(int docNum) throws IOException {
-    try {
-      thc.collect(docNum);
-    } catch (TimeExceededException tee) {
+  // obsoleted since 5.x
+  //@Override
+  //public void collect(int docNum) throws IOException {
+  //  try {
+  //    thc.collect(docNum);
+  //  } catch (TimeExceededException tee) {
       // re-throw
-      throw new LimitedException(TYPE_TIME, maxTime, tee.getTimeElapsed(), tee.getLastDocCollected());
-    }
-  }
+  //    throw new LimitedException(TYPE_TIME, maxTime, tee.getTimeElapsed(), tee.getLastDocCollected());
+  //  }
+  //}
 
-  @Override
-  public boolean acceptsDocsOutOfOrder() {
-    return outOfOrder;
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public boolean acceptsDocsOutOfOrder() {
+  //  return outOfOrder;
+  //}
 
-  @Override
-  public void setNextReader(AtomicReaderContext context) throws IOException {
-    this.docBase = context.docBase;
-    thc.setNextReader(context);
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void setNextReader(AtomicReaderContext context) throws IOException {
+  //  this.docBase = context.docBase;
+  //  thc.setNextReader(context);
+  //}
 
-  @Override
-  public void setScorer(Scorer scorer) throws IOException {
-    this.scorer = scorer;
-    if (shouldScore) {
-      thc.setScorer(scorer);
-    } else {
-      thc.setScorer(NoScoringScorer.INSTANCE);
-    }
-  }
+  // obsoleted since 5.x
+  //@Override
+  //public void setScorer(Scorer scorer) throws IOException {
+  //  this.scorer = scorer;
+  //  if (shouldScore) {
+  //    thc.setScorer(scorer);
+  //  } else {
+  //    thc.setScorer(NoScoringScorer.INSTANCE);
+  //  }
+  //}
 
   @Override
   public void reset() {
     lastDoc = 0;
-    tdc = TopScoreDocCollector.create(1000, outOfOrder);
+    tdc = TopScoreDocCollector.create(1000);
     thc = new TimeLimitingCollector(tdc, TimeLimitingCollector.getGlobalCounter(), maxTime);
+  }
+
+  @Override
+  public LeafCollector getLeafCollector(LeafReaderContext leafReaderContext) throws IOException {
+    return thc.getLeafCollector(leafReaderContext);
+  }
+
+  @Override
+  public boolean needsScores() {
+    return thc.needsScores();
   }
 }

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -114,7 +114,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
   private boolean keepCommits = false;
   // never read
   //private boolean multi = false;
-  private int tiiDiv = 1;
+  //private int tiiDiv = 1;
   private IndexCommit currentCommit = null;
   private Similarity similarity = null;
   private Object lastST;
@@ -629,12 +629,15 @@ public class Luke extends Thinlet implements ClipboardOwner {
 
     boolean force = getBoolean(find(dialog, "force"), "selected");
     boolean noReader = getBoolean(find(dialog, "cbNoReader"), "selected");
+    // DirectoryReader.open(Directory, termInfosIndexDivisor) was removed at 5.0.
+    /*
     tiiDiv = 1;
     try {
       tiiDiv = Integer.parseInt(getString(find(dialog, "tiiDiv"), "text"));
     } catch (Exception e) {
       e.printStackTrace();
     }
+    */
     Object dirImpl = getSelectedItem(find(dialog, "dirImpl"));
     String dirClass = null;
     if (dirImpl == null) {
@@ -682,7 +685,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
         errorMsg("ERROR: " + e.toString());
       }
     } else {
-      openIndex(pName, force, dirClass, readOnly, ram, keepCommits, null, tiiDiv);
+      openIndex(pName, force, dirClass, readOnly, ram, keepCommits, null);
     }
   }
   
@@ -823,7 +826,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
       return;
     }
     openIndex(pName, false, dir.getClass().getName(), readOnly, ram,
-        keepCommits, currentCommit, tiiDiv);
+        keepCommits, currentCommit);
   }
   
   /**
@@ -834,7 +837,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
    * @param ro open in read-only mode, and disallow modifications.
    */
   public void openIndex(String name, boolean force, String dirImpl, boolean ro,
-      boolean ramdir, boolean keepCommits, IndexCommit point, int tiiDivisor) {
+      boolean ramdir, boolean keepCommits, IndexCommit point) {
     pName = name;
     readOnly = ro;
     removeAll();
@@ -1179,9 +1182,9 @@ public class Luke extends Thinlet implements ClipboardOwner {
         verText = Long.toHexString(((DirectoryReader)ir).getVersion());
       }
       setString(iVer, "text", verText);
+      /*
       Object iTiiDiv = find(pOver, "iTiiDiv");
       String divText = "N/A";
-      /*
       if (ir instanceof DirectoryReader) {
         List<LeafReaderContext> readers = ((DirectoryReader) ir).leaves(); //.getSequentialSubReaders();
         if (readers.size() > 0)
@@ -1191,8 +1194,8 @@ public class Luke extends Thinlet implements ClipboardOwner {
           }
         }
       }
-      */
       setString(iTiiDiv, "text", divText);
+      */
       Object iCommit = find(pOver, "iCommit");
       String commitText = "N/A";
       if (ic != null) {
@@ -5262,7 +5265,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
           return null;
         }
       }
-      if (pName != null) luke.openIndex(pName, force, null, ro, ramdir, false, null, 1);
+      if (pName != null) luke.openIndex(pName, force, null, ro, ramdir, false, null);
       if(xmlQueryParserFactoryClassName != null) luke.setParserFactoryClassName(xmlQueryParserFactoryClassName);
       if (script != null) {
         LukePlugin plugin = luke.getPlugin("org.getopt.luke.plugins.ScriptingPlugin");

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -115,7 +115,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
   private boolean keepCommits = false;
   // never read
   //private boolean multi = false;
-  //private int tiiDiv = 1;
   private IndexCommit currentCommit = null;
   private Similarity similarity = null;
   private Object lastST;
@@ -630,15 +629,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
 
     boolean force = getBoolean(find(dialog, "force"), "selected");
     boolean noReader = getBoolean(find(dialog, "cbNoReader"), "selected");
-    // DirectoryReader.open(Directory, termInfosIndexDivisor) was removed at 5.0.
-    /*
-    tiiDiv = 1;
-    try {
-      tiiDiv = Integer.parseInt(getString(find(dialog, "tiiDiv"), "text"));
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    */
     Object dirImpl = getSelectedItem(find(dialog, "dirImpl"));
     String dirClass = null;
     if (dirImpl == null) {
@@ -954,12 +944,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
       ArrayList<DirectoryReader> readers = new ArrayList<DirectoryReader>();
       for (Directory dd : dirs) {
         DirectoryReader reader;
-        // DirectoryReader.open(Directory, int) was removed at 5.0.
-        //if (tiiDivisor > 1) {
-        //reader = DirectoryReader.open(dd, tiiDivisor);
-        //} else {
         reader = DirectoryReader.open(dd);
-        //}
         readers.add(reader);
       }
       if (readers.size() == 1) {
@@ -1183,20 +1168,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
         verText = Long.toHexString(((DirectoryReader)ir).getVersion());
       }
       setString(iVer, "text", verText);
-      /*
-      Object iTiiDiv = find(pOver, "iTiiDiv");
-      String divText = "N/A";
-      if (ir instanceof DirectoryReader) {
-        List<LeafReaderContext> readers = ((DirectoryReader) ir).leaves(); //.getSequentialSubReaders();
-        if (readers.size() > 0)
-        {
-          if (readers.get(0).reader() instanceof SegmentReader) {
-          divText = String.valueOf(((SegmentReader) readers.get(0).reader()).getTermInfosIndexDivisor());
-          }
-        }
-      }
-      setString(iTiiDiv, "text", divText);
-      */
       Object iCommit = find(pOver, "iCommit");
       String commitText = "N/A";
       if (ic != null) {

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -65,6 +65,7 @@ import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -1001,11 +1002,11 @@ public class Luke extends Thinlet implements ClipboardOwner {
     }
     try {
       Class implClass = Class.forName(dirImpl);
-      Constructor<Directory> constr = implClass.getConstructor(File.class);
+      Constructor<Directory> constr = implClass.getConstructor(Path.class);
       if (constr != null) {
-        res = constr.newInstance(f);
+        res = constr.newInstance(FileSystems.getDefault().getPath(file));
       } else {
-        constr = implClass.getConstructor(File.class, LockFactory.class);
+        constr = implClass.getConstructor(Path.class, LockFactory.class);
         res = constr.newInstance(f, (LockFactory)null);
       }
     } catch (Throwable e) {

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -2985,7 +2985,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
             showStatus("Term Vector not available in field " + fName + " for this doc.");
             return;
           }
-          List<IntPair> tvs = TermVectorMapper.map(tfv, null, true, false);
+          List<IntPair> tvs = TermVectorMapper.map(tfv, true, false);
           if (tvs == null || tvs.isEmpty()) {
             showStatus("Term Vector not available (empty).");
             return;
@@ -3414,7 +3414,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
         try {
           String fld = getString(fCombo, "text");
           Terms terms = MultiFields.getTerms(ir, fld);
-          TermsEnum te = terms.iterator(null);
+          TermsEnum te = terms.iterator();
           putProperty(fCombo, "te", te);
           putProperty(fCombo, "teField", fld);
           BytesRef term = te.next();
@@ -3458,7 +3458,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
           String rawString = rawTerm != null ? rawTerm.utf8ToString() : null;
           if (te == null || !teField.equals(fld) || !text.equals(rawString)) {
             Terms terms = MultiFields.getTerms(ir, fld);
-            te = terms.iterator(null);
+            te = terms.iterator();
             putProperty(fCombo, "te", te);
             putProperty(fCombo, "teField", fld);
             status = te.seekCeil(new BytesRef(text));
@@ -3480,7 +3480,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
               if (terms == null) {
                 continue;
               }
-              te = terms.iterator(null);
+              te = terms.iterator();
               rawTerm = te.next();
               putProperty(fCombo, "te", te);
               putProperty(fCombo, "teField", fld);
@@ -3528,7 +3528,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
           Term t = new Term(fld, text);
           if (ir.docFreq(t) == 0) { // missing term
             Terms terms = MultiFields.getTerms(ir, fld);
-            TermsEnum te = terms.iterator(null);
+            TermsEnum te = terms.iterator();
             te.seekCeil(new BytesRef(text));
             t = new Term(fld, te.term().utf8ToString());
           }
@@ -4096,7 +4096,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
     }
   }
 
-  public void explainStructure(Object qTabs) {
+  public void explainStructure(Object qTabs) throws IOException {
     Object qField = find("qField");
     String queryS = getString(qField, "text");
     if (queryS.trim().equals("")) {
@@ -4116,7 +4116,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
     _explainStructure(tree, q);
   }
   
-  private void _explainStructure(Object parent, Query q) {
+  private void _explainStructure(Object parent, Query q) throws IOException {
     String clazz = q.getClass().getName();
     if (clazz.startsWith("org.apache.lucene.")) {
       clazz = "lucene." + q.getClass().getSimpleName();
@@ -4275,7 +4275,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
     } else if (q instanceof MultiTermQuery) {
       MultiTermQuery mq = (MultiTermQuery)q;
       Set<Term> terms = new HashSet<Term>();
-      mq.extractTerms(terms);
+      mq.createWeight(is, false).extractTerms(terms);
       setString(n, "text", getString(n, "text") + ", terms: " + terms);
       try {
         addTermsEnum(n, TermRangeQuery.class, mq.getField(), mq);
@@ -4358,7 +4358,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
         String defField = getDefaultField(find("srchOptTabs"));
         setString(n, "text", "class=" + q.getClass().getName() + ", " + getString(n, "text") + ", toString=" + q.toString(defField));
         HashSet<Term> terms = new HashSet<Term>();
-        sq.extractTerms(terms);
+        sq.createWeight(is, false).extractTerms(terms);
         Object n1 = null;
         if (terms != null) {
           n1 = create("node");
@@ -4411,7 +4411,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
       Object n1 = create("node");
       String defField = getDefaultField(find("srchOptTabs"));
       Set<Term> terms = new HashSet<Term>();
-      q.extractTerms(terms);
+      q.createWeight(is, false).extractTerms(terms);
       setString(n1, "text", q.getClass().getName() + ": " + q.toString(defField));
       add(n, n1);
       if (!terms.isEmpty()) {

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -3951,63 +3951,31 @@ public class Luke extends Thinlet implements ClipboardOwner {
     String arg = getString(find(srchOpts, "snoName"), "text");
     if (arg == null) arg = "";
     try {
-      Constructor zeroArg = null, zeroArgV = null, oneArg = null, oneArgV = null;
-      /*
-      try {
-        zeroArgV = Class.forName(sAType).getConstructor(new Class[]{Version.class});
-      } catch (NoSuchMethodException e) {
-        zeroArgV = null;
-        try {
-          zeroArg = Class.forName(sAType).getConstructor(new Class[0]);
-        } catch (NoSuchMethodException e1) {
-          zeroArg = null;
-        }
-      }
-      */
+      // Analyzer's constructor no longer take Lucene Version since 5.0.
+      // https://issues.apache.org/jira/browse/LUCENE-5859
+      // Constructor zeroArg = null, zeroArgV = null, oneArg = null, oneArgV = null;
+      Constructor zeroArg = null, oneArg = null;
       try {
         zeroArg = Class.forName(sAType).getConstructor(new Class[0]);
       } catch (NoSuchMethodException e1) {
         zeroArg = null;
       }
-      /*
-      try {
-        oneArgV = Class.forName(sAType).getConstructor(new Class[]{Version.class, String.class});
-      } catch (NoSuchMethodException e) {
-        oneArgV = null;
-        try {
-          oneArg = Class.forName(sAType).getConstructor(new Class[]{String.class});
-        } catch (NoSuchMethodException e1) {
-          oneArg = null;
-        }
-      }
-      */
       try {
         oneArg = Class.forName(sAType).getConstructor(new Class[]{String.class});
       } catch (NoSuchMethodException e1) {
         oneArg = null;
       }
       if (arg.length() == 0) {
-        //if (zeroArgV != null) {
-          //res = (Analyzer)zeroArgV.newInstance(LV);
-          //res = (Analyzer)zeroArgV.newInstance();
-        //} else if (zeroArg != null) {
         if (zeroArg != null) {
           res = (Analyzer)zeroArg.newInstance();
-        //} else if (oneArgV != null) {
-          //res = (Analyzer)oneArgV.newInstance(new Object[]{LV, arg});
-          //res = (Analyzer)oneArgV.newInstance(new Object[]{arg});
         } else if (oneArg != null) {
           res = (Analyzer)oneArg.newInstance(new Object[]{arg});
         } else {
           throw new Exception("Must have a zero-arg or (Version) or (Version, String) constructor");
         }
       } else {
-        if (oneArgV != null) {
-          res = (Analyzer)oneArgV.newInstance(new Object[]{LV, arg});
-        } else if (oneArg != null) {
+        if (oneArg != null) {
           res = (Analyzer)oneArg.newInstance(new Object[]{arg});
-        } else if (zeroArgV != null) {
-          res = (Analyzer)zeroArgV.newInstance(new Object[]{LV});
         } else if (zeroArg != null) {
           res = (Analyzer)zeroArg.newInstance(new Object[0]);
         } else {

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -854,9 +854,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
       if (IndexWriter.isLocked(d)) {
         if (!ro) {
           if (force) {
-            // IndexWriter.unlock() was removed.
-            // https://issues.apache.org/jira/browse/LUCENE-6060
-            // IndexWriter.unlock(d);
             d.makeLock(IndexWriter.WRITE_LOCK_NAME).close();
           } else {
             errorMsg("Index is locked. Try 'Force unlock' when opening.");
@@ -886,7 +883,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
           if (IndexWriter.isLocked(d1)) {
             if (!ro) {
               if (force) {
-                // IndexWriter.unlock(d1);
                 d1.makeLock(IndexWriter.WRITE_LOCK_NAME).close();
               } else {
                 errorMsg("Index is locked. Try 'Force unlock' when opening.");
@@ -2695,9 +2691,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
         ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
       }
       ft.setStored(getBoolean(cbStored, "selected"));
-      // IndexableFieldType.indexed() and FieldType.setIndexed() were removed at 5.0.
-      // https://issues.apache.org/jira/browse/LUCENE-6013
-      // ft.setIndexed(getBoolean(cbIndexed, "selected"));
       ft.setTokenized(getBoolean(cbTokenized, "selected"));
       if (ft.stored() == false && ft.indexOptions() == null) {
         errorMsg("Field '" + name + "' is neither stored nor indexed.");
@@ -3926,9 +3919,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
     String arg = getString(find(srchOpts, "snoName"), "text");
     if (arg == null) arg = "";
     try {
-      // Analyzer's constructor no longer take Lucene Version since 5.0.
-      // https://issues.apache.org/jira/browse/LUCENE-5859
-      // Constructor zeroArg = null, zeroArgV = null, oneArg = null, oneArgV = null;
       Constructor zeroArg = null, oneArg = null;
       try {
         zeroArg = Class.forName(sAType).getConstructor(new Class[0]);
@@ -4087,7 +4077,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
     boolean orderRes = getBoolean(ckOrderRes, "selected");
     Collector hc = null;
     if (getBoolean(ckNormRes, "selected")) {
-      return new AccessibleTopHitCollector(1000, orderRes, scoreRes);
+      return new AccessibleTopHitCollector(1000);
     } else if (getBoolean(ckAllRes, "selected")) {
       return new AllHitsCollector();
     } else if (getBoolean(ckLimRes, "selected")) {
@@ -4097,7 +4087,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
         return new CountLimitedHitCollector(lim);
       } else if (getBoolean(ckLimTime, "selected")) {
         int lim = Integer.parseInt(getString(limTime, "text"));
-        return new IntervalLimitedCollector(lim, orderRes, scoreRes);
+        return new IntervalLimitedCollector(lim);
       } else {
         throw new Exception("Unknown LimitedHitCollector type");
       }
@@ -4300,8 +4290,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
       setString(n, "text", getString(n, "text") + ", " + cq.toString());
       Object n1 = create("node");
       add(n, n1);
-      // https://issues.apache.org/jira/browse/LUCENE-1518
-      //if (cq.getFilter() != null) {
       if (cq.getQuery() != null) {
         setString(n1, "text", "Filter: " + cq.getQuery().toString());
       } else if (cq.getQuery() != null) {
@@ -4618,7 +4606,7 @@ public class Luke extends Thinlet implements ClipboardOwner {
   private void _search(final Query q, final IndexSearcher is,
           AccessibleHitCollector hc, final Object sTable, final int repeat) throws Exception {
     if (hc == null) {
-      hc = new AccessibleTopHitCollector(1000, true, true);
+      hc = new AccessibleTopHitCollector(1000);
     }
     final AccessibleHitCollector collector = hc;
     le = null;

--- a/src/main/java/org/getopt/luke/Ranges.java
+++ b/src/main/java/org/getopt/luke/Ranges.java
@@ -1,14 +1,10 @@
 package org.getopt.luke;
 
-//import org.apache.lucene.util.OpenBitSet;
 import org.apache.lucene.util.FixedBitSet;
 
 @SuppressWarnings("serial")
 public class Ranges {
 
-  // OpenBitSet has been deleted.
-  // https://issues.apache.org/jira/browse/LUCENE-5440
-  // https://issues.apache.org/jira/browse/LUCENE-6010
   public static FixedBitSet parse(String expr) throws Exception {
     FixedBitSet res = new FixedBitSet(64);
     expr = expr.replaceAll("\\s+", "");
@@ -32,12 +28,4 @@ public class Ranges {
     return res;
   }
 
-  /*
-  public void set(int from, int to) {
-    if (from > to) return;
-    for (int i = from; i <= to; i++) {
-      set(i);
-    }
-  }
-  */
 }

--- a/src/main/java/org/getopt/luke/Ranges.java
+++ b/src/main/java/org/getopt/luke/Ranges.java
@@ -1,12 +1,16 @@
 package org.getopt.luke;
 
-import org.apache.lucene.util.OpenBitSet;
+//import org.apache.lucene.util.OpenBitSet;
+import org.apache.lucene.util.FixedBitSet;
 
 @SuppressWarnings("serial")
-public class Ranges extends OpenBitSet {
-  
-  public static Ranges parse(String expr) throws Exception {
-    Ranges res = new Ranges();
+public class Ranges {
+
+  // OpenBitSet has been deleted.
+  // https://issues.apache.org/jira/browse/LUCENE-5440
+  // https://issues.apache.org/jira/browse/LUCENE-6010
+  public static FixedBitSet parse(String expr) throws Exception {
+    FixedBitSet res = new FixedBitSet(64);
     expr = expr.replaceAll("\\s+", "");
     if (expr.length() == 0) {
       return res;
@@ -17,19 +21,23 @@ public class Ranges extends OpenBitSet {
       int from, to;
       from = Integer.parseInt(ft[0]);
       if (ft.length == 1) {
+        res = FixedBitSet.ensureCapacity(res, from);
         res.set(from);
       } else {
         to = Integer.parseInt(ft[1]);
+        res = FixedBitSet.ensureCapacity(res, to);
         res.set(from, to);
       }
     }
     return res;
   }
-  
+
+  /*
   public void set(int from, int to) {
     if (from > to) return;
     for (int i = from; i <= to; i++) {
       set(i);
     }
   }
+  */
 }

--- a/src/main/java/org/getopt/luke/TermVectorMapper.java
+++ b/src/main/java/org/getopt/luke/TermVectorMapper.java
@@ -14,8 +14,8 @@ import java.util.List;
  */
 public class TermVectorMapper {
 
-  public static List<IntPair> map(Terms terms, TermsEnum reuse, boolean acceptTermsOnly, boolean convertOffsets) throws IOException {
-    TermsEnum te = terms.iterator(reuse);
+  public static List<IntPair> map(Terms terms, boolean acceptTermsOnly, boolean convertOffsets) throws IOException {
+    TermsEnum te = terms.iterator();
     DocsAndPositionsEnum dpe = null;
     List<IntPair> res = new ArrayList<IntPair>();
     while (te.next() != null) {

--- a/src/main/java/org/getopt/luke/Util.java
+++ b/src/main/java/org/getopt/luke/Util.java
@@ -14,11 +14,11 @@ import org.apache.lucene.document.DateTools.Resolution;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FieldType.NumericType;
-import org.apache.lucene.index.AtomicReader;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.CompositeReader;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FieldInfo.DocValuesType;
-import org.apache.lucene.index.FieldInfo.IndexOptions;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.SlowCompositeReaderWrapper;
@@ -159,16 +159,16 @@ public class Util {
   }
   
   public static Collection<String> fieldNames(IndexReader r, boolean indexedOnly) throws IOException {
-    AtomicReader reader;
+    LeafReader reader;
     if (r instanceof CompositeReader) {
       reader = SlowCompositeReaderWrapper.wrap(r);
     } else {
-      reader = (AtomicReader)r;
+      reader = (LeafReader)r;
     }
     Set<String> res = new HashSet<String>();
     FieldInfos infos = reader.getFieldInfos();
     for (FieldInfo info : infos) {
-      if (indexedOnly && info.isIndexed()) {
+      if (indexedOnly && info.getIndexOptions() != IndexOptions.NONE) {
         res.add(info.name);
         continue;
       }
@@ -201,7 +201,7 @@ public class Util {
     Number numeric = null;
     if (fld == null) {
       t = new FieldType();
-      t.setIndexed(false);
+      t.setIndexOptions(IndexOptions.NONE);
       t.setStored(false);
       t.setStoreTermVectors(false);
       t.setOmitNorms(true);
@@ -215,12 +215,12 @@ public class Util {
       numeric = fld.numericValue();
     }
     StringBuffer flags = new StringBuffer();
-    if (info.isIndexed()) flags.append("I");
+    if (info.getIndexOptions() != IndexOptions.NONE) flags.append("I");
     else flags.append("-");
     IndexOptions opts = info.getIndexOptions();
-    if (info.isIndexed() && opts != null) {
+    if (info.getIndexOptions() != IndexOptions.NONE && opts != null) {
       switch (opts) {
-      case DOCS_ONLY:
+      case DOCS:
         flags.append("d---");
         break;
       case DOCS_AND_FREQS:
@@ -245,9 +245,11 @@ public class Util {
     else flags.append("-");
     if (info.hasNorms()) {
       flags.append("N");
-      flags.append(dvToString(info.getNormType()));
+      // TODO: FieldInfo#getNormType was deleted in Lucene 5
+      //flags.append(dvToString(info.getNormType()));
     }
-    else flags.append("----");
+    //else flags.append("----");
+    else flags.append("-");
     if (numeric != null) {
       flags.append("#");
       NumericType nt = t.numericType();
@@ -284,7 +286,7 @@ public class Util {
     } else {
       flags.append("----");
     }
-    if (info.hasDocValues()) {
+    if (info.getDocValuesType() != DocValuesType.NONE) {
       flags.append("D");
       flags.append(dvToString(info.getDocValuesType()));
     } else {

--- a/src/main/java/org/getopt/luke/XMLExporter.java
+++ b/src/main/java/org/getopt/luke/XMLExporter.java
@@ -7,6 +7,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
 import org.getopt.luke.decoders.Decoder;
 
 import java.io.*;
@@ -76,7 +77,7 @@ public class XMLExporter extends Observable {
    * @throws Exception
    */
   public boolean export(OutputStream output, boolean decode, boolean preamble, boolean info,
-      String rootElementName, Ranges ranges) throws Exception {
+      String rootElementName, FixedBitSet ranges) throws Exception {
     running = true;
     pn.message = "Export running ...";
     pn.minValue = 0;
@@ -111,7 +112,7 @@ public class XMLExporter extends Observable {
       Document doc = null;
       int i = -1;
       if (ranges == null) {
-        ranges = new Ranges();
+        ranges = new FixedBitSet(leafReader.maxDoc());
         ranges.set(0, leafReader.maxDoc());
       }
       if (ranges.cardinality() > 0) {
@@ -368,7 +369,7 @@ public class XMLExporter extends Observable {
       throw new Exception("Output file already exists: '" + out.getAbsolutePath() + "'");
     }
     boolean gzip = false;
-    Ranges ranges = null;
+    FixedBitSet ranges = null;
     boolean onlyInfo = false;
     for (int i = 2; i < args.length; i++) {
       if (args[i].equals("-gzip")) {
@@ -393,7 +394,7 @@ public class XMLExporter extends Observable {
       os = new GZIPOutputStream(os);
     }
     if (onlyInfo) {
-      ranges = new Ranges();
+      ranges = new FixedBitSet(64);
     }
     exporter.export(os, false, false, true, "index", ranges);
     os.flush();

--- a/src/main/java/org/getopt/luke/XMLExporter.java
+++ b/src/main/java/org/getopt/luke/XMLExporter.java
@@ -226,7 +226,7 @@ public class XMLExporter extends Observable {
   
   private void writeTermVector(BufferedWriter bw, Terms tfv, Bits liveDocs) throws Exception {
     bw.write("<tv>\n");
-    TermsEnum te = tfv.iterator(null);
+    TermsEnum te = tfv.iterator();
     DocsAndPositionsEnum dpe = null;
     StringBuilder positions = new StringBuilder();
     StringBuilder offsets = new StringBuilder();

--- a/src/main/java/org/getopt/luke/plugins/AnalyzerToolPlugin.java
+++ b/src/main/java/org/getopt/luke/plugins/AnalyzerToolPlugin.java
@@ -63,36 +63,6 @@ public class AnalyzerToolPlugin extends LukePlugin {
     }
     app.setInteger(combobox, "selected", 0);
     app.setString(combobox, "text", firstClass);
-    // Analyzer's constructor no longer take Lucene Version since 5.0.
-    // https://issues.apache.org/jira/browse/LUCENE-5859
-    /*
-    Object aVersion = app.find(myUi, "aVersion");
-    app.removeAll(aVersion);
-    Version[] values = {
-            Version.LUCENE_4_0_0,
-            Version.LUCENE_4_1_0,
-            Version.LUCENE_4_2_0,
-            Version.LUCENE_4_3_0,
-            Version.LUCENE_4_4_0,
-            Version.LUCENE_4_5_0,
-            Version.LUCENE_4_6_0,
-            Version.LUCENE_4_7_0,
-            Version.LUCENE_4_8_0,
-            Version.LUCENE_4_9_0,
-            Version.LUCENE_4_10_0,
-            Version.LATEST
-    };
-    for (int i = 0; i < values.length; i++) {
-      Version v = values[i];
-      Object choice = app.create("choice");
-      app.setString(choice, "text", v.toString());
-      app.putProperty(choice, "version", v);
-      app.add(aVersion, choice);
-      if (v.equals(Luke.LV)) {
-        app.setInteger(aVersion, "selected", i);
-      }
-    }
-    */
     return true;
   }
   

--- a/src/main/java/org/getopt/luke/plugins/AnalyzerToolPlugin.java
+++ b/src/main/java/org/getopt/luke/plugins/AnalyzerToolPlugin.java
@@ -63,6 +63,9 @@ public class AnalyzerToolPlugin extends LukePlugin {
     }
     app.setInteger(combobox, "selected", 0);
     app.setString(combobox, "text", firstClass);
+    // Analyzer's constructor no longer take Lucene Version since 5.0.
+    // https://issues.apache.org/jira/browse/LUCENE-5859
+    /*
     Object aVersion = app.find(myUi, "aVersion");
     app.removeAll(aVersion);
     Version[] values = {
@@ -89,6 +92,7 @@ public class AnalyzerToolPlugin extends LukePlugin {
         app.setInteger(aVersion, "selected", i);
       }
     }
+    */
     return true;
   }
   
@@ -98,27 +102,19 @@ public class AnalyzerToolPlugin extends LukePlugin {
       Object resultsList = app.find(myUi, "resultsList");
       Object inputText = app.find(myUi, "inputText");
       String classname = app.getString(combobox, "text");
-      Object choice = app.getSelectedItem(app.find(myUi, "aVersion"));
-      Version v = (Version)app.getProperty(choice, "version");
       Class clazz = Class.forName(classname);
       Analyzer analyzer = null;
       try {
-        Constructor<Analyzer> c = clazz.getConstructor(Version.class);
-        analyzer = c.newInstance(v);
-      } catch (Throwable t) {
-        try {
-          // no constructor with Version ?
-          analyzer = (Analyzer)clazz.newInstance();
-        } catch (Throwable t1) {
-          t1.printStackTrace();
-          app
-                .showStatus("Couldn't instantiate analyzer - public 0-arg or 1-arg constructor(Version) required");
-          return;
-        }
+        analyzer = (Analyzer)clazz.newInstance();
+      } catch (Throwable t1) {
+        t1.printStackTrace();
+        app
+          .showStatus("Couldn't instantiate analyzer - public 0-arg or 1-arg constructor(Version) required");
+        return;
       }
 
 
-        TokenStream ts = analyzer.tokenStream("text", new StringReader(app
+      TokenStream ts = analyzer.tokenStream("text", new StringReader(app
               .getString(inputText, "text")));
         ts.reset();
 

--- a/src/main/java/org/getopt/luke/plugins/AnalyzerToolPlugin.java
+++ b/src/main/java/org/getopt/luke/plugins/AnalyzerToolPlugin.java
@@ -66,13 +66,6 @@ public class AnalyzerToolPlugin extends LukePlugin {
     Object aVersion = app.find(myUi, "aVersion");
     app.removeAll(aVersion);
     Version[] values = {
-            Version.LUCENE_3_0_0,
-            Version.LUCENE_3_1_0,
-            Version.LUCENE_3_2_0,
-            Version.LUCENE_3_3_0,
-            Version.LUCENE_3_4_0,
-            Version.LUCENE_3_5_0,
-            Version.LUCENE_3_6_0,
             Version.LUCENE_4_0_0,
             Version.LUCENE_4_1_0,
             Version.LUCENE_4_2_0,

--- a/src/main/java/org/getopt/luke/plugins/FsDirectory.java
+++ b/src/main/java/org/getopt/luke/plugins/FsDirectory.java
@@ -174,30 +174,14 @@ public class FsDirectory extends Directory {
 
   public Lock makeLock(final String name) {
       if (lock == null) {
-          lock = lockFactory.makeLock(name);
+          lock = lockFactory.makeLock(this, name);
       }
       return lock;
   }
 
-    @Override
-    public void clearLock(String s) throws IOException {
-        lock.close();
-        lock = null;
-    }
-
     public synchronized void close() throws IOException {
     fs.close();
   }
-
-    @Override
-    public void setLockFactory(LockFactory _lockFactory) throws IOException {
-        lockFactory = _lockFactory;
-    }
-
-    @Override
-    public LockFactory getLockFactory() {
-        return lockFactory;
-    }
 
     public String toString() {
     return this.getClass().getName() + "@" + directory;
@@ -299,8 +283,8 @@ public class FsDirectory extends Directory {
     private RandomAccessFile local;
     private File localFile;
 
-    public DfsIndexOutput(Path path, int ioFileBufferSize) throws IOException {
-        super(new FileOutputStream(new File(path.toUri())), ioFileBufferSize);
+    public DfsIndexOutput(String resourceDescription, Path path, int ioFileBufferSize) throws IOException {
+        super(resourceDescription, new FileOutputStream(new File(path.toUri())), ioFileBufferSize);
 
         // create a temporary local file and set it to delete on exit
       String randStr = Integer.toString(new Random().nextInt(Integer.MAX_VALUE));

--- a/src/main/java/org/getopt/luke/plugins/FsDirectory.java
+++ b/src/main/java/org/getopt/luke/plugins/FsDirectory.java
@@ -283,10 +283,10 @@ public class FsDirectory extends Directory {
     private RandomAccessFile local;
     private File localFile;
 
-    public DfsIndexOutput(String resourceDescription, Path path, int ioFileBufferSize) throws IOException {
-        super(resourceDescription, new FileOutputStream(new File(path.toUri())), ioFileBufferSize);
+    public DfsIndexOutput(Path path, int ioFileBufferSize) throws IOException {
+      super("", new FileOutputStream(new File(path.toUri())), ioFileBufferSize);
 
-        // create a temporary local file and set it to delete on exit
+      // create a temporary local file and set it to delete on exit
       String randStr = Integer.toString(new Random().nextInt(Integer.MAX_VALUE));
       localFile = File.createTempFile("index_" + randStr, ".tmp");
       localFile.deleteOnExit();

--- a/src/main/java/org/getopt/luke/plugins/VocabAnalysisPlugin.java
+++ b/src/main/java/org/getopt/luke/plugins/VocabAnalysisPlugin.java
@@ -104,7 +104,7 @@ public class VocabAnalysisPlugin extends LukePlugin {
           float numDocs = ir.maxDoc();
           if (numDocs < numAgeGroups) numAgeGroups = ir.maxDoc();
           float ageTotals[] = new float[numAgeGroups];
-          TermsEnum te = MultiFields.getTerms(ir, field).iterator(null);
+          TermsEnum te = MultiFields.getTerms(ir, field).iterator();
           while (te.next() != null) {
             DocsEnum td = te.docs(null, null, 0);
             td.nextDoc();

--- a/src/main/java/org/getopt/luke/plugins/ZipfAnalysisPlugin.java
+++ b/src/main/java/org/getopt/luke/plugins/ZipfAnalysisPlugin.java
@@ -103,7 +103,7 @@ public class ZipfAnalysisPlugin extends LukePlugin {
       public void execute() {
         try {
           int numBuckets = 100;
-          TermsEnum te = MultiFields.getTerms(ir, field).iterator(null);
+          TermsEnum te = MultiFields.getTerms(ir, field).iterator();
           ArrayList<TermCount> terms = new ArrayList<TermCount>();
 
           // most terms occur very infrequently - just keep group totals for the DFs

--- a/src/main/resources/xml/at-plugin.xml
+++ b/src/main/resources/xml/at-plugin.xml
@@ -3,9 +3,7 @@
 	 weighty="1">
 	<panel gap="2" weightx="1" halign="fill" columns="2">
    <label text="Available analyzers found on the current classpath:" />
-   <label text="Compatibility:"/>
    <combobox name="analyzers" enabled="true" editable="true" selected="0" halign="fill" weightx="1"/>
-   <combobox name="aVersion" enabled="true" editable="false" selected="0" halign="fill" weightx="1"/>
 	</panel>
 	<label text="Text to be analyzed:" />
 	<textarea name="inputText" wrap="true" text="Welcome to the analysis viewer. This tool is used to demonstrate how different analyzers process text into tokens. You can edit this text to try different input such as numbers like 23231.23 or characters (mharwood@apache.org). Once happy, select an Analyzer from the list of analyzers found on the current classpath and then hit the Analyze button. The tokens produced are shown below and when you select them the right panel shows their attributes, and the corresponding span in the original text is highlighted." rows="5" weightx="1"/>

--- a/src/main/resources/xml/luke.xml
+++ b/src/main/resources/xml/luke.xml
@@ -49,6 +49,7 @@
                                         <label halign="right" font="10" text="Index version:"/><label font="10" name="iVer" text="?"/>
                                         <label halign="right" font="10" text="Index format:"/><label font="10" name="iFormat" text="?"/>
                                         <label halign="right" font="10" text="Index functionality:"/><label font="10" name="iCaps" text="?"/>
+					                    <!-- TODO: DirectoryReader.open(Directory, termInfosIndexDivisor) was removed at 5.0. We should remove this line -->
                                         <label halign="right" font="10" text="TermInfos index divisor:"/><label font="10" name="iTiiDiv" text="?"/>
                                         <label halign="right" font="10" text="Directory implementation:"/><label font="10" name="dirImpl" text="?"/>
                                         <label halign="right" font="10" text="Currently opened commit point:"/><label font="10" name="iCommit" text=""/>

--- a/src/main/resources/xml/luke.xml
+++ b/src/main/resources/xml/luke.xml
@@ -49,8 +49,6 @@
                                         <label halign="right" font="10" text="Index version:"/><label font="10" name="iVer" text="?"/>
                                         <label halign="right" font="10" text="Index format:"/><label font="10" name="iFormat" text="?"/>
                                         <label halign="right" font="10" text="Index functionality:"/><label font="10" name="iCaps" text="?"/>
-					                    <!-- TODO: DirectoryReader.open(Directory, termInfosIndexDivisor) was removed at 5.0. We should remove this line -->
-                                        <label halign="right" font="10" text="TermInfos index divisor:"/><label font="10" name="iTiiDiv" text="?"/>
                                         <label halign="right" font="10" text="Directory implementation:"/><label font="10" name="dirImpl" text="?"/>
                                         <label halign="right" font="10" text="Currently opened commit point:"/><label font="10" name="iCommit" text=""/>
                                         <label halign="right" font="10" text="Current commit user data:"/><label font="10" name="iUser" text=""/>

--- a/src/main/resources/xml/lukeinit.xml
+++ b/src/main/resources/xml/lukeinit.xml
@@ -26,6 +26,7 @@
               <checkbox font="10" name="cbKeepCommits" text="Keep all commit points" selected="true"/>
               <checkbox font="10" name="cbNoReader" text="Don't open IndexReader (when opening corrupted index)"/>
               <checkbox font="10" name="cbSlowIO" text="Slow IO - avoid and track expensive IO operations"/>
+		      <!-- TODO: DirectoryReader.open(Directory, termInfosIndexDivisor) was removed at 5.0. We should remove following 4 lines -->
               <panel gap="2">
                 <label font="10" text="Custom TermInfos divisor:"/>
                 <textfield font="10" columns="4" name="tiiDiv" text="1"/>

--- a/src/main/resources/xml/lukeinit.xml
+++ b/src/main/resources/xml/lukeinit.xml
@@ -26,11 +26,6 @@
               <checkbox font="10" name="cbKeepCommits" text="Keep all commit points" selected="true"/>
               <checkbox font="10" name="cbNoReader" text="Don't open IndexReader (when opening corrupted index)"/>
               <checkbox font="10" name="cbSlowIO" text="Slow IO - avoid and track expensive IO operations"/>
-		      <!-- TODO: DirectoryReader.open(Directory, termInfosIndexDivisor) was removed at 5.0. We should remove following 4 lines -->
-              <panel gap="2">
-                <label font="10" text="Custom TermInfos divisor:"/>
-                <textfield font="10" columns="4" name="tiiDiv" text="1"/>
-              </panel>
         </panel>
 	<separator/>
 	<panel weightx="1" halign="right" gap="8" top="3" right="3" bottom="2">

--- a/src/test/java/org.apache.lucene.index/IndexTester.java
+++ b/src/test/java/org.apache.lucene.index/IndexTester.java
@@ -10,6 +10,8 @@ import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.Version;
 
 import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 
 /**
  * Created by dmitry on 4/3/15.
@@ -38,21 +40,21 @@ public class IndexTester extends TestCase {
     }
 
     private void populate() throws Exception {
-        // create an org.apache.lucene.index
-        Directory directory = NIOFSDirectory.open(new File(indexPath));
-        indexCfg = new IndexWriterConfig(Version.LUCENE_4_10_3, new UAX29URLEmailAnalyzer());
-        indexCfg.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+      Path path = FileSystems.getDefault().getPath(indexPath);
+      Directory directory = NIOFSDirectory.open(path);
+      indexCfg = new IndexWriterConfig(new UAX29URLEmailAnalyzer());
+      indexCfg.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
 
-        IndexWriter writer = new IndexWriter(directory, indexCfg);
+      IndexWriter writer = new IndexWriter(directory, indexCfg);
 
-        Document doc = new Document();
-        doc.add(new StringField("aaa", "1", Field.Store.NO));
-        doc.add(new Field("bbb", "2", Field.Store.NO, Field.Index.NOT_ANALYZED));
+      Document doc = new Document();
+      doc.add(new StringField("aaa", "1", Field.Store.NO));
+      doc.add(new Field("bbb", "2", Field.Store.NO, Field.Index.NOT_ANALYZED));
 
-        // sanity check
-        doc.add(new StringField("ccc", "3", Field.Store.YES));
+      // sanity check
+      doc.add(new StringField("ccc", "3", Field.Store.YES));
 
-        writer.addDocument(doc);
-        writer.close();
+      writer.addDocument(doc);
+      writer.close();
     }
 }


### PR DESCRIPTION
This is a draft pull request. Comments and reviews are appreciated.
All compiling errors have been resolved, and the build module can browse Lucene 4.x and 5.1 indexes.

Todos:
* Some old codes still remain (commented out) -- should be deleted when they are merged to trunk.
* UIs for "TermInfos index divisor" should be removed -- I think, but not sure...
  * line 53 of luke.xml and line 30 to 33 of lukeinit.xml
* Components other than Lucene should be upgraded?
  * I upgraded only Lucene version to 5.1.0 in pom.xml

Notes:
* Custom classes for Elasticsearch (e.g. org.apache.lucene.analysis.PrefixAnalyzer) does not work because ES 1.5 supports Lucene 4.

Thanks.