### PR TITLE
Added copy, cut, paste etc. shortcuts, using Mac command key.

### DIFF
--- a/src/main/java/thinlet/Thinlet.java
+++ b/src/main/java/thinlet/Thinlet.java
@@ -2953,11 +2953,11 @@ public class Thinlet extends Container implements Runnable, Serializable {
                 KeyEvent ke = (KeyEvent) e;
                 int keychar = ke.getKeyChar();
                 boolean control = (keychar <= 0x1f) || ((keychar >= 0x7f) && (keychar <= 0x9f)) || (keychar >= 0xffff)
-                        || ke.isControlDown();
+                        || ke.isControlDown() || ke.isMetaDown();
                 int keycode = control ? ke.getKeyCode() : 0;
                 if ((control == (id == KeyEvent.KEY_PRESSED))
                         && processKeyPress((popupowner != null) ? popupowner : focusowner, ke.isShiftDown(), ke
-                                .isControlDown(), ke.getModifiers(), control ? 0 : keychar, keycode)) {
+                                .isControlDown() || ke.isMetaDown(), ke.getModifiers(), control ? 0 : keychar, keycode)) {
                     ke.consume();
                 } else if ((keycode == KeyEvent.VK_TAB)
                         || ((keycode == KeyEvent.VK_F6) && (ke.isAltDown() || ke.isControlDown()))) {


### PR DESCRIPTION
Luke never supported Mac command+c, command+x, command+v, etc. for copy, paste, cut, select all and so on. Now it does.