### PR TITLE
pivot-luke-5.5.0 references wrong jar file name

### DIFF
--- a/luke.sh
+++ b/luke.sh
@@ -1,12 +1,12 @@
 if [[ -d `echo $LUKE_PATH` ]]; then
-  java -jar $LUKE_PATH/target/luke-with-deps.jar
+  java -jar $LUKE_PATH/target/pivot-luke-with-deps.jar
 else
   echo "Unable to find the LUKE_PATH environnement variable..."
   echo "Assuming you're running from the root folder of luke..."
-   java -jar target/luke-with-deps.jar
+   java -jar target/pivot-luke-with-deps.jar
 fi
 #
 # In order to start luke with your custom analyzer class extending org.apache.lucene.analysis.Analyzer run:
 # java -cp target/luke-with-deps.jar:/path/to/custom_analyzer.jar org.getopt.luke.Luke
 # your analyzer should appear in the drop-down menu with analyzers on the Search tab
-#java -cp target/luke-with-deps.jar:/home/dmitry/projects/github/suggestinganalyzer/target/suggestinganalyzer-1.0-SNAPSHOT.jar org.getopt.luke.Luke
+#java -cp target/pivot-luke-with-deps.jar:/home/dmitry/projects/github/suggestinganalyzer/target/suggestinganalyzer-1.0-SNAPSHOT.jar org.getopt.luke.Luke


### PR DESCRIPTION
pivot-luke-5.5.0 references wrong jar file name

https://github.com/DmitryKey/luke/releases

Was getting this error

$ ./luke.sh 
Unable to find the LUKE_PATH environnement variable...
Assuming you're running from the root folder of luke...
Error: Unable to access jarfile ./target/luke-with-deps.jar