### PR TITLE
Specify width attribute for TableView.column element.

### DIFF
--- a/src/main/resources/org/apache/lucene/luke/ui/DocValuesDialog.bxml
+++ b/src/main/resources/org/apache/lucene/luke/ui/DocValuesDialog.bxml
@@ -33,11 +33,11 @@
 
 				<TablePane.Row>
 					<Border styles="{padding:1}">
-						<ScrollPane horizontalScrollBarPolicy="fill_to_capacity" preferredHeight="250" minimumWidth="300">
+						<ScrollPane horizontalScrollBarPolicy="fill_to_capacity" preferredHeight="250" minimumWidth="450">
 							<TableView bxml:id="data" selectMode="multi">
 								<columns>
 								<TableView.Column name="value"
-																	headerData="%docValuesDialog_table_col1" />
+																	headerData="%docValuesDialog_table_col1" width="1*"/>
 								</columns>
 							</TableView>
 						</ScrollPane>


### PR DESCRIPTION
Fix for https://github.com/DmitryKey/luke/pull/53#issuecomment-204756579

Seems "width" attribute must be specified.

![pivot-luke-docvalues4](https://cloud.githubusercontent.com/assets/1825333/14231320/c48e3d02-f9b9-11e5-93a4-a552df0399d2.png)
