### PR TITLE
Upgrade lucene version to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <lucene.version>5.5.0</lucene.version>
+        <lucene.version>6.0.0</lucene.version>
         <ehcache.version>2.9.0</ehcache.version>
         <hadoop.version>1.2.1</hadoop.version>
         <log4j.version>1.2.17</log4j.version>

--- a/src/main/java/org/apache/lucene/index/IndexGate.java
+++ b/src/main/java/org/apache/lucene/index/IndexGate.java
@@ -195,7 +195,7 @@ public class IndexGate {
             res.capabilities = "flexible, codec-specific";
             int actualVersion = SegmentInfos.VERSION_53;
             try {
-              actualVersion = CodecUtil.checkHeaderNoMagic(in, "segments", SegmentInfos.VERSION_40, Integer.MAX_VALUE);
+              actualVersion = CodecUtil.checkHeaderNoMagic(in, "segments", SegmentInfos.VERSION_50, Integer.MAX_VALUE);
               if (actualVersion > SegmentInfos.VERSION_53) {
                 res.capabilities += " (WARNING: newer version of Lucene than this tool)";
                 System.out.println("WARNING: newer version of Lucene than this tool supports");
@@ -205,22 +205,6 @@ public class IndexGate {
               res.capabilities += " (error reading: " + e.getMessage() + ")";
             }
             switch(actualVersion) {
-              case SegmentInfos.VERSION_40:
-                res.genericName = "Lucene 4.0 or later";
-                res.version = "4.0 or later";
-                break;
-              case SegmentInfos.VERSION_46:
-                res.genericName = "Lucene 4.6 or later";
-                res.version = "4.6 or later";
-                break;
-              case SegmentInfos.VERSION_48:
-                res.genericName = "Lucene 4.8 or later";
-                res.version = "4.8 or later";
-                break;
-              case SegmentInfos.VERSION_49:
-                res.genericName = "Lucene 4.9 or later";
-                res.version = "4.9 or later";
-                break;
               case SegmentInfos.VERSION_50:
                 res.genericName = "Lucene 5.0";
                 res.version = "5.0";
@@ -235,9 +219,9 @@ public class IndexGate {
                 break;
             }
           } else {
-            res.genericName = "Lucene 3.x or prior";
+            res.genericName = "Lucene 4.x or prior";
             detectOldFormats(res, indexFormat);
-            if (res.version.compareTo("3") < 0) {
+            if (res.version.compareTo("4") < 0) {
               res.capabilities = res.capabilities + " (UNSUPPORTED)";
             }
           }

--- a/src/main/java/org/getopt/luke/DocReconstructor.java
+++ b/src/main/java/org/getopt/luke/DocReconstructor.java
@@ -124,8 +124,10 @@ public class DocReconstructor extends Observable {
             res.getReconstructedFields().put(fieldNames[i], gsa);
           }
           for (IntPair ip : vectors) {
-            for (int m = 0; m < ip.positions.length; m++) {
-              gsa.append(ip.positions[m], "|", ip.text);
+            if (ip.positions != null) {
+              for (int m = 0; m < ip.positions.length; m++) {
+                gsa.append(ip.positions[m], "|", ip.text);
+              }
             }
           }
           fields.remove(fieldNames[i]); // got what we wanted
@@ -185,7 +187,9 @@ public class DocReconstructor extends Observable {
         }
         for (int k = 0; k < pe.freq(); k++) {
           int pos = pe.nextPosition();
-          gsa.append(pos, "|", docTerm);
+          if (pos > -1) {
+            gsa.append(pos, "|", docTerm);
+          }
         }
       }
     }

--- a/src/main/java/org/getopt/luke/DocReconstructor.java
+++ b/src/main/java/org/getopt/luke/DocReconstructor.java
@@ -108,7 +108,7 @@ public class DocReconstructor extends Observable {
     progress.curValue = 0;
     progress.minValue = 0;
     TermsEnum te = null;
-    DocsAndPositionsEnum dpe = null;
+    PostingsEnum pe = null;
     for (int i = 0; i < fieldNames.length; i++) {
       Terms tvf = reader.getTermVector(docNum, fieldNames[i]);
       if (tvf != null) { // has vectors for this field
@@ -153,9 +153,9 @@ public class DocReconstructor extends Observable {
         // first use bytesRef to extract the indexed term value
         String docTerm = bytesRef.utf8ToString();
 
-        DocsAndPositionsEnum newDpe = te.docsAndPositions(live, dpe, 0);
+        PostingsEnum newPe = te.postings(pe, 0);
 
-        if (newDpe == null) { // no position info for this field
+        if (newPe == null) { // no position info for this field
             // re-construct without positions
             GrowableStringArray gsa = (GrowableStringArray)
                     res.getReconstructedFields().get(fld);
@@ -169,9 +169,9 @@ public class DocReconstructor extends Observable {
         }
 
         // we should have positions as well for the field, process them accordingly
-        dpe = newDpe;
+        pe = newPe;
 
-        int num = dpe.advance(docNum);
+        int num = pe.advance(docNum);
         if (num != docNum) { // either greater than or NO_MORE_DOCS
           continue; // no data for this term in this doc
         }
@@ -184,8 +184,8 @@ public class DocReconstructor extends Observable {
           gsa = new GrowableStringArray();
           res.getReconstructedFields().put(fld, gsa);
         }
-        for (int k = 0; k < dpe.freq(); k++) {
-          int pos = dpe.nextPosition();
+        for (int k = 0; k < pe.freq(); k++) {
+          int pos = pe.nextPosition();
           gsa.append(pos, "|", docTerm);
         }
       }

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -851,16 +851,14 @@ public class Luke extends Thinlet implements ClipboardOwner {
     Throwable lastException = null;
     try {
       Directory d = openDirectory(dirImpl, pName, false);
-      if (IndexWriter.isLocked(d)) {
-        if (!ro) {
-          if (force) {
-            d.obtainLock(IndexWriter.WRITE_LOCK_NAME).close();
-          } else {
-            errorMsg("Index is locked. Try 'Force unlock' when opening.");
-            d.close();
-            d = null;
-            return;
-          }
+      if (!ro) {
+        if (force) {
+          d.obtainLock(IndexWriter.WRITE_LOCK_NAME).close();
+        } else {
+          errorMsg("Index is locked. Try 'Force unlock' when opening.");
+          d.close();
+          d = null;
+          return;
         }
       }
       boolean existsSingle = false;
@@ -880,16 +878,14 @@ public class Luke extends Thinlet implements ClipboardOwner {
             continue;
           }
           Directory d1 = openDirectory(dirImpl, f.toString(), false);
-          if (IndexWriter.isLocked(d1)) {
-            if (!ro) {
-              if (force) {
-                d1.obtainLock(IndexWriter.WRITE_LOCK_NAME).close();
-              } else {
-                errorMsg("Index is locked. Try 'Force unlock' when opening.");
-                d1.close();
-                d1 = null;
-                return;
-              }
+          if (!ro) {
+            if (force) {
+              d1.obtainLock(IndexWriter.WRITE_LOCK_NAME).close();
+            } else {
+              errorMsg("Index is locked. Try 'Force unlock' when opening.");
+              d1.close();
+              d1 = null;
+              return;
             }
           }
           existsSingle = false;

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -1211,11 +1211,11 @@ public class Luke extends Thinlet implements ClipboardOwner {
     // sort by names now
     String[] idxFieldsCopy = idxFields.clone();
 
-      // sort by term count
-      ValueComparator bvc =  new ValueComparator(termCounts);
-      TreeMap<String,FieldTermCount> termCountsSorted = new TreeMap<String,FieldTermCount>(bvc);
-      termCountsSorted.putAll(termCounts);
-      String[] idxFieldsCopySorted = termCountsSorted.keySet().toArray(new String[idxFieldsCopy.length]);
+    // sort by term count
+    ValueComparator bvc =  new ValueComparator(termCounts);
+    TreeMap<String,FieldTermCount> termCountsSorted = new TreeMap<String,FieldTermCount>(bvc);
+    termCountsSorted.putAll(termCounts);
+    String[] idxFieldsCopySorted = termCountsSorted.keySet().toArray(new String[idxFieldsCopy.length]);
 
     populateFieldGrid(fList, fCombo, defFld, intCountFormat, percentFormat, idxFieldsCopySorted);
 

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -1215,7 +1215,18 @@ public class Luke extends Thinlet implements ClipboardOwner {
     ValueComparator bvc =  new ValueComparator(termCounts);
     TreeMap<String,FieldTermCount> termCountsSorted = new TreeMap<String,FieldTermCount>(bvc);
     termCountsSorted.putAll(termCounts);
-    String[] idxFieldsCopySorted = termCountsSorted.keySet().toArray(new String[idxFieldsCopy.length]);
+    String[] sortedFields = termCountsSorted.keySet().toArray(new String[termCounts.size()]);
+    String[] idxFieldsCopySorted = new String[idxFields.length];
+    System.arraycopy(sortedFields, 0, idxFieldsCopySorted, 0, sortedFields.length);
+    if (termCounts.size() < idxFieldsCopy.length) {
+      int idx = sortedFields.length;
+      for (String f : idxFields) {
+        if (!termCounts.containsKey(f)) {
+          idxFieldsCopySorted[idx] = f;
+          idx += 1;
+        }
+      }
+    }
 
     populateFieldGrid(fList, fCombo, defFld, intCountFormat, percentFormat, idxFieldsCopySorted);
 

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -1926,12 +1926,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
         ir.close();
         ir = null;
       }
-      if (ir instanceof CompositeReader) {
-        CompositeReader cr = (CompositeReader)ir;
-        for (LeafReaderContext ctx : cr.leaves()) {
-          ctx.reader().close();
-        }
-      }
       if (dir != null) {
         dir.close();
         dir = null;
@@ -2151,12 +2145,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
       }
       if (ir != null) {
         ir.close();
-      }
-      if (ir instanceof CompositeReader) {
-        CompositeReader cr = (CompositeReader)ir;
-        for (LeafReaderContext ctx : cr.leaves()) {
-          ctx.reader().close();
-        }
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -2398,12 +2386,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
         try {
           if (is != null) is = null;
           if (ir != null) ir.close();
-          if (ir instanceof CompositeReader) {
-            CompositeReader cr = (CompositeReader)ir;
-            for (LeafReaderContext ctx : cr.leaves()) {
-              ctx.reader().close();
-            }
-          }
           IndexDeletionPolicy policy;
           if (keep) {
             policy = new KeepAllIndexDeletionPolicy();
@@ -2752,11 +2734,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
     String msg = null;
     try {
       ir.close();
-      if (ir instanceof CompositeReader) {
-        for (LeafReaderContext ctx : ir.leaves()) {
-          ctx.reader().close();
-        }
-      }
       writer = createIndexWriter();
       writer.addDocument(doc);
       res = true;

--- a/src/main/java/org/getopt/luke/Luke.java
+++ b/src/main/java/org/getopt/luke/Luke.java
@@ -854,11 +854,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
       if (!ro) {
         if (force) {
           d.obtainLock(IndexWriter.WRITE_LOCK_NAME).close();
-        } else {
-          errorMsg("Index is locked. Try 'Force unlock' when opening.");
-          d.close();
-          d = null;
-          return;
         }
       }
       boolean existsSingle = false;
@@ -881,11 +876,6 @@ public class Luke extends Thinlet implements ClipboardOwner {
           if (!ro) {
             if (force) {
               d1.obtainLock(IndexWriter.WRITE_LOCK_NAME).close();
-            } else {
-              errorMsg("Index is locked. Try 'Force unlock' when opening.");
-              d1.close();
-              d1 = null;
-              return;
             }
           }
           existsSingle = false;

--- a/src/main/java/org/getopt/luke/TermVectorMapper.java
+++ b/src/main/java/org/getopt/luke/TermVectorMapper.java
@@ -18,7 +18,7 @@ public class TermVectorMapper {
     PostingsEnum pe = null;
     List<IntPair> res = new ArrayList<IntPair>();
     while (te.next() != null) {
-      PostingsEnum newPe = te.postings(null, 1);
+      PostingsEnum newPe = te.postings(pe);
       if (newPe == null) { // no positions and no offsets - just add terms if allowed
         if (!acceptTermsOnly) {
           return null;

--- a/src/main/java/org/getopt/luke/Util.java
+++ b/src/main/java/org/getopt/luke/Util.java
@@ -233,14 +233,10 @@ public class Util {
     else flags.append("-");
     if (info.hasNorms()) {
       flags.append("N");
-      // TODO: FieldInfo#getNormType was deleted in Lucene 5
-      //flags.append(dvToString(info.getNormType()));
     }
-    //else flags.append("----");
     else flags.append("-");
     if (numeric != null) {
       flags.append("#");
-      //NumericType nt = t.numericType();
       FieldType.LegacyNumericType nt = t.numericType();
       if (nt != null) {
         flags.append(nt.toString().charAt(0));
@@ -279,31 +275,44 @@ public class Util {
       flags.append("D");
       flags.append(dvToString(info.getDocValuesType()));
     } else {
+      flags.append("-------");
+    }
+    if (info.getPointDimensionCount() > 0) {
+      int dim = info.getPointDimensionCount();
+      int nbytes = info.getPointNumBytes();
+      flags.append("T");
+      flags.append(String.valueOf(nbytes));
+      flags.append("/");
+      flags.append(String.valueOf(dim));
+    } else {
       flags.append("----");
-    }    
+    }
     return flags.toString();
   }
   
   private static String dvToString(DocValuesType type) {
     String fl;
     if (type == null) {
-      return "???";
+      return "??????";
     }
     switch (type) {
-    case NUMERIC:
-      fl = "num";
-      break;
-    case BINARY:
-      fl = "bin";
-      break;
-    case SORTED:
-      fl = "srt";
-      break;
-    case SORTED_SET:
-      fl = "srtset";
-      break;
-    default:
-      fl = "???";
+      case NUMERIC:
+        fl = "number";
+        break;
+      case BINARY:
+        fl = "binary";
+        break;
+      case SORTED:
+        fl = "sorted";
+        break;
+      case SORTED_NUMERIC:
+        fl = "srtnum";
+        break;
+      case SORTED_SET:
+        fl = "srtset";
+        break;
+      default:
+        fl = "??????";
     }
     return fl;
   }

--- a/src/main/java/org/getopt/luke/Util.java
+++ b/src/main/java/org/getopt/luke/Util.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import org.apache.lucene.document.DateTools.Resolution;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.FieldType.NumericType;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.CompositeReader;
 import org.apache.lucene.index.FieldInfo;
@@ -252,7 +251,8 @@ public class Util {
     else flags.append("-");
     if (numeric != null) {
       flags.append("#");
-      NumericType nt = t.numericType();
+      //NumericType nt = t.numericType();
+      FieldType.LegacyNumericType nt = t.numericType();
       if (nt != null) {
         flags.append(nt.toString().charAt(0));
         int prec = t.numericPrecisionStep();

--- a/src/main/java/org/getopt/luke/Util.java
+++ b/src/main/java/org/getopt/luke/Util.java
@@ -5,22 +5,12 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.lucene.document.DateTools.Resolution;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.CompositeReader;
-import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.FieldInfos;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.SlowCompositeReaderWrapper;
+import org.apache.lucene.index.*;
 import org.apache.lucene.search.similarities.TFIDFSimilarity;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
@@ -158,14 +148,14 @@ public class Util {
   }
   
   public static Collection<String> fieldNames(IndexReader r, boolean indexedOnly) throws IOException {
-    LeafReader reader;
+    FieldInfos infos;
     if (r instanceof CompositeReader) {
-      reader = SlowCompositeReaderWrapper.wrap(r);
+      infos = MultiFields.getMergedFieldInfos(r);
     } else {
-      reader = (LeafReader)r;
+      LeafReader reader = (LeafReader)r;
+      infos = reader.getFieldInfos();
     }
     Set<String> res = new HashSet<String>();
-    FieldInfos infos = reader.getFieldInfos();
     for (FieldInfo info : infos) {
       if (indexedOnly && info.getIndexOptions() != IndexOptions.NONE) {
         res.add(info.name);
@@ -175,7 +165,7 @@ public class Util {
     }
     return res;
   }
-  
+
   public static float decodeNormValue(long v, String fieldName, TFIDFSimilarity sim) throws Exception {
     try {
       return sim.decodeNormValue(v);
@@ -191,7 +181,6 @@ public class Util {
       throw new Exception("ERROR encoding norm for field "  + fieldName + ":" + e.toString());
     }    
   }
-
 
   // IdfpoPSVBNtxx#txxDtxx
   public static String fieldFlags(Field fld, FieldInfo info) {

--- a/src/main/java/org/getopt/luke/XMLExporter.java
+++ b/src/main/java/org/getopt/luke/XMLExporter.java
@@ -227,35 +227,35 @@ public class XMLExporter extends Observable {
   private void writeTermVector(BufferedWriter bw, Terms tfv, Bits liveDocs) throws Exception {
     bw.write("<tv>\n");
     TermsEnum te = tfv.iterator();
-    DocsAndPositionsEnum dpe = null;
+    PostingsEnum pe = null;
     StringBuilder positions = new StringBuilder();
     StringBuilder offsets = new StringBuilder();
     while (te.next() != null) {
       // collect
       positions.setLength(0);
       offsets.setLength(0);
-      DocsAndPositionsEnum newDpe = te.docsAndPositions(liveDocs, dpe,
-              1);
-      if (newDpe == null) {
+      //DocsAndPositionsEnum newDpe = te.docsAndPositions(liveDocs, dpe,           1);
+      PostingsEnum newPe = te.postings(pe, 1);
+      if (newPe == null) {
         continue;
       }
-      dpe = newDpe;
+      pe = newPe;
       // there's only at most one doc here, so position the enum
-      if (dpe.nextDoc() == DocsEnum.NO_MORE_DOCS) {
+      if (pe.nextDoc() == PostingsEnum.NO_MORE_DOCS) {
         continue;
       }
-      for (int k = 0; k < dpe.freq(); k++) {
-        int pos = dpe.nextPosition();
+      for (int k = 0; k < pe.freq(); k++) {
+        int pos = pe.nextPosition();
         if (pos != -1) { // has positions
           if (positions.length() > 0) positions.append(' ');
           positions.append(String.valueOf(pos));
         }
-        if (dpe.startOffset() != -1) { // has offsets
+        if (pe.startOffset() != -1) { // has offsets
           if (offsets.length() > 0) offsets.append(' ');
-          offsets.append(dpe.startOffset() + "-" + dpe.endOffset());
+          offsets.append(pe.startOffset() + "-" + pe.endOffset());
         }
       }
-      bw.write("<t text='" + Util.xmlEscape(te.term().utf8ToString()) + "' freq='" + dpe.freq() + "'");
+      bw.write("<t text='" + Util.xmlEscape(te.term().utf8ToString()) + "' freq='" + pe.freq() + "'");
       if (positions.length() > 0) {
         bw.write(" positions='" + positions.toString() + "'");
       }

--- a/src/main/java/org/getopt/luke/decoders/NumIntDecoder.java
+++ b/src/main/java/org/getopt/luke/decoders/NumIntDecoder.java
@@ -9,7 +9,8 @@ public class NumIntDecoder implements Decoder {
   @Override
   public String decodeTerm(String fieldName, Object value) {
     BytesRef ref = new BytesRef(value.toString());
-    return Integer.toString(NumericUtils.prefixCodedToInt(ref));
+    //return Integer.toString(NumericUtils.prefixCodedToInt(ref));
+    return Long.toString(NumericUtils.sortableBytesToInt(ref.bytes, 0));
   }
   
   @Override

--- a/src/main/java/org/getopt/luke/decoders/NumLongDecoder.java
+++ b/src/main/java/org/getopt/luke/decoders/NumLongDecoder.java
@@ -9,7 +9,8 @@ public class NumLongDecoder implements Decoder {
   @Override
   public String decodeTerm(String fieldName, Object value) {
     BytesRef ref = new BytesRef(value.toString());
-    return Long.toString(NumericUtils.prefixCodedToLong(ref));
+    //return Long.toString(NumericUtils.prefixCodedToLong(ref));
+    return Long.toString(NumericUtils.sortableBytesToLong(ref.bytes, 0));
   }
   
   @Override

--- a/src/main/java/org/getopt/luke/plugins/VocabAnalysisPlugin.java
+++ b/src/main/java/org/getopt/luke/plugins/VocabAnalysisPlugin.java
@@ -1,8 +1,8 @@
 package org.getopt.luke.plugins;
 
-import org.apache.lucene.index.DocsEnum;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.TermsEnum;
 import org.getopt.luke.LukePlugin;
 import org.getopt.luke.SlowThread;
@@ -106,9 +106,9 @@ public class VocabAnalysisPlugin extends LukePlugin {
           float ageTotals[] = new float[numAgeGroups];
           TermsEnum te = MultiFields.getTerms(ir, field).iterator();
           while (te.next() != null) {
-            DocsEnum td = te.docs(null, null, 0);
-            td.nextDoc();
-            float firstDocId = td.docID();
+            PostingsEnum pe = te.postings(null, 0);
+            pe.nextDoc();
+            float firstDocId = pe.docID();
             int ageBracket = (int) ((firstDocId / numDocs) * numAgeGroups);
             ageTotals[ageBracket]++;
           }

--- a/src/main/resources/xml/luke.xml
+++ b/src/main/resources/xml/luke.xml
@@ -186,16 +186,20 @@
 						<label text="  P - Payloads" font="10"/>
 						<label text="  S - Stored;" font="10"/>
 						<label text="  V - Term Vector" font="10"/>
-						<label text="  B - Binary;" font="10"/>
-                        <label text="Ntxx - Norms (type/precision);" font="10"/>
+						<label text="B - Binary;" font="10"/>
+						<label text="  N - Norms (type/precision);" font="10"/>
 						<label text="  #txx - Numeric (type/precision);" font="10"/>
-						<label text="  Dtxx - DocValues (type/precision)" font="10"/>
+						<label text="" font="10"/>
+						<label text="Dtxxxxx - DocValues (type/precision);" font="10"/>
+						<label text="  Tx/x - PointValues (numBytes/dimension);" font="10"/>
+						<label text="" font="10"/>
+						<label text="" font="10"/>
 					</panel>
 				</panel>
 				<table name="docTable" halign="fill" selection="multiple" weightx="1" valign="fill" weighty="1">
 					<header>
 						<column text=" Field"/>
-						<column text="IdfpoPSVBNtxx#txxDtxx" alignment="center" width="150" font="Courier"/>
+						<column text="IdfpoPSVBN#txxDtxxxxxTx/x" alignment="center" width="160" font="Courier"/>
 						<column text="Norm" width="50" alignment="center"/>
 						<column text=" Value"/>
 					</header>

--- a/src/test/java/org.apache.lucene.index/IndexTester.java
+++ b/src/test/java/org.apache.lucene.index/IndexTester.java
@@ -49,7 +49,7 @@ public class IndexTester extends TestCase {
 
       Document doc = new Document();
       doc.add(new StringField("aaa", "1", Field.Store.NO));
-      doc.add(new Field("bbb", "2", Field.Store.NO, Field.Index.NOT_ANALYZED));
+      doc.add(new StringField("bbb", "2", Field.Store.YES));
 
       // sanity check
       doc.add(new StringField("ccc", "3", Field.Store.YES));


### PR DESCRIPTION
Those fixes are for Lucene 6.0.0 API changes.
- Changed APIs: NumericField (IntField is now LegacyIntField, and other NumericFields are also prefixed with 'Legacy')
- Removed APIs: DocsEnum, PayloadNearQuery, PayloadTermQuery, Query.setBoost()
- Deprecated APIs: IndexWriter.isLocked()

And, to support PointValues introduced at lucene 6.0.0, 
- Stop using SlowCompositeReaderWrapper (that cannot wrap LeafReaders that contains PointValues)
- Show PointValues (the dimension and num bytes per dimension)  in documents tab.

I have roughly tested those fixes with 'techproducts' example included with Solr 6.0.0. It can browse the index, optimize index, show docs, add new docs.
More tests may be needed, I need your help. Please try this branch :)

Thanks.