### PR TITLE
Pom warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>luke</groupId>
     <artifactId>luke</artifactId>
-    <version>${lucene.version}</version>
+    <version>6.2.1</version>
 
     <properties>
         <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <lucene.version>6.2.1</lucene.version>
+        <lucene.version>${project.version}</lucene.version>
         <ehcache.version>2.9.0</ehcache.version>
         <hadoop.version>1.2.1</hadoop.version>
         <log4j.version>1.2.17</log4j.version>

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -8,6 +8,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
+            <outputDirectory>luke-${lucene.version}</outputDirectory>
             <includes>
                 <include>luke.sh</include>
                 <include>luke.bat</include>
@@ -15,7 +16,7 @@
         </fileSet>
         <fileSet>
             <directory>target</directory>
-            <outputDirectory>target</outputDirectory>
+            <outputDirectory>luke-${lucene.version}/target</outputDirectory>
             <includes>
                 <include>luke-with-deps.jar</include>
             </includes>


### PR DESCRIPTION
fixed a Maven warning because of the dynamic version. It's not as readable as before but Maven doesn't complain anymore.