### PR TITLE
Update lucene to version 6.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>luke</groupId>
     <artifactId>luke</artifactId>
-    <version>6.3.0</version>
+    <version>6.4.0</version>
 
     <properties>
         <jdk.version>1.8</jdk.version>


### PR DESCRIPTION
Changed the luke version and thereby the lucene version to 6.4.0.

I ran `package` and the resulting jar started and successfully opened my index. (No further testing yet)

Also see #77 