### PR TITLE
Lucene 6.4.1 and dependency/maven-plugin updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
         <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lucene.version>${project.version}</lucene.version>
-        <ehcache.version>2.9.0</ehcache.version>
+        <ehcache.version>2.10.3</ehcache.version>
         <hadoop.version>1.2.1</hadoop.version>
         <log4j.version>1.2.17</log4j.version>
-        <rhino.version>1.7R4</rhino.version>
+        <rhino.version>1.7.7.1</rhino.version>
         <elasticsearch.version>1.6.0</elasticsearch.version>
 
         <maven-shade-plugin.version>2.3</maven-shade-plugin.version>
@@ -129,12 +129,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.7</version>
+            <version>1.7.22</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,10 @@
     <artifactId>luke</artifactId>
     <version>6.4.1</version>
 
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
+
     <properties>
         <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -18,13 +22,13 @@
         <rhino.version>1.7.7.1</rhino.version>
         <elasticsearch.version>1.6.0</elasticsearch.version>
 
-        <maven-shade-plugin.version>2.3</maven-shade-plugin.version>
-        <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
-        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
-        <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-        <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
-        <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
+        <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
+        <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
+        <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.0.0</maven-dependency-plugin.version>
+        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
         <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.3</version>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>luke</groupId>
     <artifactId>luke</artifactId>
-    <version>6.4.0</version>
+    <version>6.4.1</version>
 
     <properties>
         <jdk.version>1.8</jdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lucene.version>${project.version}</lucene.version>
         <ehcache.version>2.10.3</ehcache.version>
-        <hadoop.version>1.2.1</hadoop.version>
+        <hadoop.version>2.7.2</hadoop.version>
         <log4j.version>1.2.17</log4j.version>
         <rhino.version>1.7.7.1</rhino.version>
         <elasticsearch.version>1.6.0</elasticsearch.version>
@@ -109,8 +109,38 @@
 
         <dependency>
         	<groupId>org.apache.hadoop</groupId>
-        	<artifactId>hadoop-core</artifactId>
+        	<artifactId>hadoop-common</artifactId>
         	<version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Lucene 6.4.1 was just released yesterday :)

#### Just to keep things up-to-date

 * Updated the dependencies to their current versions.
 * I added a requirement for maven 3.0 to the pom
 * Updated the maven plugins to their current versions.
 * Added versions-maven-plugin to make it easy to check for updates


I built luke and it successfully opens my index and i can browse it.
But I have not tested more advanced features.