### PR TITLE
fix edit columns

### DIFF
--- a/src/main/resources/xml/luke.xml
+++ b/src/main/resources/xml/luke.xml
@@ -353,6 +353,7 @@
 						<panel gap="4" weightx="1" halign="fill">
 							<label font="bold" text="Results:"/>
 							<label font="10" text="  (Hint: Double-click on results to display all fields)" weightx="1" halign="fill"/>
+							<button text="Edit columns" tooltip="Select and re-order columns" action="editColumns"/>
 							<separator/>
 							<button text="Explain" icon="/img/info.gif" tooltip="Explain selected result" action="explainResult(sTable)"/>
                                                         <separator/>


### PR DESCRIPTION
@DmitryKey I forgot one (crucial) file in the previous PR.

You should see the edit columns button now (next to the "explain" button")

<img width="853" alt="screen shot 2018-09-27 at 17 06 01" src="https://user-images.githubusercontent.com/10405266/46151628-db3e7380-c277-11e8-8add-f66a03e3f564.png">

