### PR TITLE
Do not invoke URLClassLoader.addURL()

### DIFF
--- a/src/main/java/org/apache/lucene/luke/app/desktop/components/AnalysisPanelProvider.java
+++ b/src/main/java/org/apache/lucene/luke/app/desktop/components/AnalysisPanelProvider.java
@@ -124,7 +124,7 @@ public class AnalysisPanelProvider implements Provider<JPanel> {
           operator.setAnalyzer(analysisModel.currentAnalyzer()));
     }
 
-    @Override
+    /*@Override
     public void addExternalJars(List<String> jarFiles) {
       analysisModel.addExternalJars(jarFiles);
       operatorRegistry.get(CustomAnalyzerPanelProvider.CustomAnalyzerPanelOperator.class).ifPresent(operator -> {
@@ -132,7 +132,7 @@ public class AnalysisPanelProvider implements Provider<JPanel> {
         operator.setAvailableTokenizerFactories(analysisModel.getAvailableTokenizerFactories());
         operator.setAvailableTokenFilterFactories(analysisModel.getAvailableTokenFilterFactories());
       });
-    }
+    }*/
 
     @Override
     public Analyzer getCurrentAnalyzer() {
@@ -157,9 +157,8 @@ public class AnalysisPanelProvider implements Provider<JPanel> {
         mainPanel.add(custom, BorderLayout.CENTER);
 
         operatorRegistry.get(CustomAnalyzerPanelProvider.CustomAnalyzerPanelOperator.class).ifPresent(operator -> {
-          operator.setAvailableCharFilterFactories(analysisModel.getAvailableCharFilterFactories());
-          operator.setAvailableTokenizerFactories(analysisModel.getAvailableTokenizerFactories());
-          operator.setAvailableTokenFilterFactories(analysisModel.getAvailableTokenFilterFactories());
+          operator.setAnalysisModel(analysisModel);
+          operator.resetAnalisComponents();
         });
       }
       mainPanel.setVisible(false);
@@ -326,7 +325,6 @@ public class AnalysisPanelProvider implements Provider<JPanel> {
   public interface AnalysisPanelOperator extends ComponentOperatorRegistry.ComponentOperator {
     void setAnalyzerByType(String analyzerType);
     void setAnalyzerByCustomConfiguration(CustomAnalyzerConfig config);
-    void addExternalJars(List<String> jarFiles);
     Analyzer getCurrentAnalyzer();
   }
 

--- a/src/main/java/org/apache/lucene/luke/app/desktop/components/AnalysisPanelProvider.java
+++ b/src/main/java/org/apache/lucene/luke/app/desktop/components/AnalysisPanelProvider.java
@@ -158,7 +158,7 @@ public class AnalysisPanelProvider implements Provider<JPanel> {
 
         operatorRegistry.get(CustomAnalyzerPanelProvider.CustomAnalyzerPanelOperator.class).ifPresent(operator -> {
           operator.setAnalysisModel(analysisModel);
-          operator.resetAnalisComponents();
+          operator.resetAnalysisComponents();
         });
       }
       mainPanel.setVisible(false);

--- a/src/main/java/org/apache/lucene/luke/app/desktop/components/AnalysisPanelProvider.java
+++ b/src/main/java/org/apache/lucene/luke/app/desktop/components/AnalysisPanelProvider.java
@@ -124,16 +124,6 @@ public class AnalysisPanelProvider implements Provider<JPanel> {
           operator.setAnalyzer(analysisModel.currentAnalyzer()));
     }
 
-    /*@Override
-    public void addExternalJars(List<String> jarFiles) {
-      analysisModel.addExternalJars(jarFiles);
-      operatorRegistry.get(CustomAnalyzerPanelProvider.CustomAnalyzerPanelOperator.class).ifPresent(operator -> {
-        operator.setAvailableCharFilterFactories(analysisModel.getAvailableCharFilterFactories());
-        operator.setAvailableTokenizerFactories(analysisModel.getAvailableTokenizerFactories());
-        operator.setAvailableTokenFilterFactories(analysisModel.getAvailableTokenFilterFactories());
-      });
-    }*/
-
     @Override
     public Analyzer getCurrentAnalyzer() {
       return analysisModel.currentAnalyzer();

--- a/src/main/java/org/apache/lucene/luke/app/desktop/components/fragments/analysis/CustomAnalyzerPanelProvider.java
+++ b/src/main/java/org/apache/lucene/luke/app/desktop/components/fragments/analysis/CustomAnalyzerPanelProvider.java
@@ -37,7 +37,6 @@ import org.apache.lucene.luke.app.desktop.util.ImageUtils;
 import org.apache.lucene.luke.app.desktop.util.MessageUtils;
 import org.apache.lucene.luke.models.LukeException;
 import org.apache.lucene.luke.models.analysis.Analysis;
-import org.apache.lucene.luke.models.analysis.AnalysisFactory;
 import org.apache.lucene.luke.models.analysis.CustomAnalyzerConfig;
 
 import javax.swing.BorderFactory;
@@ -148,7 +147,7 @@ public class CustomAnalyzerPanelProvider implements Provider<JPanel> {
         File[] files = fileChooser.getSelectedFiles();
         analysisModel.addExternalJars(Arrays.stream(files).map(File::getAbsolutePath).collect(Collectors.toList()));
         operatorRegistry.get(CustomAnalyzerPanelOperator.class).ifPresent(operator ->
-          operator.resetAnalisComponents()
+          operator.resetAnalysisComponents()
         );
         messageBroker.showStatusMessage("External jars were added.");
       }
@@ -303,7 +302,7 @@ public class CustomAnalyzerPanelProvider implements Provider<JPanel> {
     }
 
     @Override
-    public void resetAnalisComponents() {
+    public void resetAnalysisComponents() {
       setAvailableCharFilterFactories();
       setAvailableTokenizerFactories();
       setAvailableTokenFilterFactories();
@@ -730,7 +729,7 @@ public class CustomAnalyzerPanelProvider implements Provider<JPanel> {
 
   public interface CustomAnalyzerPanelOperator extends ComponentOperatorRegistry.ComponentOperator {
     void setAnalysisModel(Analysis analysisModel);
-    void resetAnalisComponents();
+    void resetAnalysisComponents();
 
     void updateCharFilters(List<Integer> deletedIndexes);
     void updateTokenFilters(List<Integer> deletedIndexes);

--- a/src/main/java/org/apache/lucene/luke/app/desktop/components/fragments/analysis/CustomAnalyzerPanelProvider.java
+++ b/src/main/java/org/apache/lucene/luke/app/desktop/components/fragments/analysis/CustomAnalyzerPanelProvider.java
@@ -35,6 +35,9 @@ import org.apache.lucene.luke.app.desktop.util.ListUtil;
 import org.apache.lucene.luke.app.desktop.util.lang.Callable;
 import org.apache.lucene.luke.app.desktop.util.ImageUtils;
 import org.apache.lucene.luke.app.desktop.util.MessageUtils;
+import org.apache.lucene.luke.models.LukeException;
+import org.apache.lucene.luke.models.analysis.Analysis;
+import org.apache.lucene.luke.models.analysis.AnalysisFactory;
 import org.apache.lucene.luke.models.analysis.CustomAnalyzerConfig;
 
 import javax.swing.BorderFactory;
@@ -120,6 +123,8 @@ public class CustomAnalyzerPanelProvider implements Provider<JPanel> {
 
   private JPanel containerPanel;
 
+  private Analysis analysisModel;
+
   class ListenerFunctions {
 
     void chooseConfigDir(ActionEvent e) {
@@ -141,9 +146,10 @@ public class CustomAnalyzerPanelProvider implements Provider<JPanel> {
       int ret = fileChooser.showOpenDialog(containerPanel);
       if (ret == JFileChooser.APPROVE_OPTION) {
         File[] files = fileChooser.getSelectedFiles();
-        operatorRegistry.get(AnalysisPanelProvider.AnalysisPanelOperator.class).ifPresent(operator -> {
-            operator.addExternalJars(Arrays.stream(files).map(File::getAbsolutePath).collect(Collectors.toList()));
-        });
+        analysisModel.addExternalJars(Arrays.stream(files).map(File::getAbsolutePath).collect(Collectors.toList()));
+        operatorRegistry.get(CustomAnalyzerPanelOperator.class).ifPresent(operator ->
+          operator.resetAnalisComponents()
+        );
         messageBroker.showStatusMessage("External jars were added.");
       }
     }
@@ -156,12 +162,17 @@ public class CustomAnalyzerPanelProvider implements Provider<JPanel> {
       List<String> tokenFilterFactories = ListUtil.getAllItems(selectedTfList);
       assert tokenFilterFactories.size() == tfParamsList.size();
 
+      String tokenizerName = analysisModel.getTokenizerFactorySPIName(selectedTokTF.getText()).orElseThrow(() -> new LukeException("No such tokenizer: " + selectedTokTF.getText()));
       CustomAnalyzerConfig.Builder builder =
-          new CustomAnalyzerConfig.Builder(selectedTokTF.getText(), tokParams).configDir(confDirTF.getText());
+          new CustomAnalyzerConfig.Builder(tokenizerName, tokParams).configDir(confDirTF.getText());
       IntStream.range(0, charFilterFactories.size()).forEach(i ->
-          builder.addCharFilterConfig(charFilterFactories.get(i), cfParamsList.get(i)));
+          analysisModel.getCharFilterFactorySPIName(charFilterFactories.get(i)).ifPresent(name ->
+              builder.addCharFilterConfig(name, cfParamsList.get(i))
+          ));
       IntStream.range(0, tokenFilterFactories.size()).forEach(i ->
-          builder.addTokenFilterConfig(tokenFilterFactories.get(i), tfParamsList.get(i)));
+          analysisModel.getTokenFilterFactorySPIName(tokenFilterFactories.get(i)).ifPresent(name ->
+              builder.addTokenFilterConfig(name, tfParamsList.get(i))
+          ));
       CustomAnalyzerConfig config = builder.build();
 
       operatorRegistry.get(AnalysisPanelProvider.AnalysisPanelOperator.class).ifPresent(operator -> {
@@ -287,23 +298,35 @@ public class CustomAnalyzerPanelProvider implements Provider<JPanel> {
   class CustomAnalyzerPanelOperatorImpl implements CustomAnalyzerPanelOperator {
 
     @Override
-    public void setAvailableCharFilterFactories(Collection<Class<? extends CharFilterFactory>> charFilters) {
+    public void setAnalysisModel(Analysis model) {
+      analysisModel = model;
+    }
+
+    @Override
+    public void resetAnalisComponents() {
+      setAvailableCharFilterFactories();
+      setAvailableTokenizerFactories();
+      setAvailableTokenFilterFactories();
+    }
+
+    private void setAvailableCharFilterFactories() {
+      Collection<Class<? extends CharFilterFactory>> charFilters = analysisModel.getAvailableCharFilterFactories();
       String[] charFilterNames = new String[charFilters.size() + 1];
       charFilterNames[0] = "";
       System.arraycopy(charFilters.stream().map(Class::getName).toArray(String[]::new), 0, charFilterNames, 1, charFilters.size());
       cfFactoryCombo.setModel(new DefaultComboBoxModel<>(charFilterNames));
     }
 
-    @Override
-    public void setAvailableTokenizerFactories(Collection<Class<? extends TokenizerFactory>> tokenizers) {
+    private void setAvailableTokenizerFactories() {
+      Collection<Class<? extends TokenizerFactory>> tokenizers = analysisModel.getAvailableTokenizerFactories();
       String[] tokenizerNames = new String[tokenizers.size() + 1];
       tokenizerNames[0] = "";
       System.arraycopy(tokenizers.stream().map(Class::getName).toArray(String[]::new), 0, tokenizerNames, 1, tokenizers.size());
       tokFactoryCombo.setModel(new DefaultComboBoxModel<>(tokenizerNames));
     }
 
-    @Override
-    public void setAvailableTokenFilterFactories(Collection<Class<? extends TokenFilterFactory>> tokenFilters) {
+    private void setAvailableTokenFilterFactories() {
+      Collection<Class<? extends TokenFilterFactory>> tokenFilters = analysisModel.getAvailableTokenFilterFactories();
       String[] tokenFilterNames = new String[tokenFilters.size() + 1];
       tokenFilterNames[0] = "";
       System.arraycopy(tokenFilters.stream().map(Class::getName).toArray(String[]::new), 0, tokenFilterNames, 1, tokenFilters.size());
@@ -706,9 +729,8 @@ public class CustomAnalyzerPanelProvider implements Provider<JPanel> {
   }
 
   public interface CustomAnalyzerPanelOperator extends ComponentOperatorRegistry.ComponentOperator {
-    void setAvailableCharFilterFactories(Collection<Class<? extends CharFilterFactory>> charFilters);
-    void setAvailableTokenizerFactories(Collection<Class<? extends TokenizerFactory>> tokenizers);
-    void setAvailableTokenFilterFactories(Collection<Class<? extends TokenFilterFactory>> tokenFilters);
+    void setAnalysisModel(Analysis analysisModel);
+    void resetAnalisComponents();
 
     void updateCharFilters(List<Integer> deletedIndexes);
     void updateTokenFilters(List<Integer> deletedIndexes);

--- a/src/main/java/org/apache/lucene/luke/models/analysis/Analysis.java
+++ b/src/main/java/org/apache/lucene/luke/models/analysis/Analysis.java
@@ -29,6 +29,7 @@ import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A dedicated interface for Luke's Analysis tab.
@@ -100,14 +101,35 @@ public interface Analysis {
   Collection<Class<? extends CharFilterFactory>> getAvailableCharFilterFactories();
 
   /**
+   * Returns the corresponding SPI name for a CharFilterFactory class name.
+   * @param className - class name
+   * @return name of the char filter factory, or empty if the factory class is not found in the current context.
+   */
+  Optional<String> getCharFilterFactorySPIName(String className);
+
+  /**
    * Returns available {@link TokenizerFactory}s.
    */
   Collection<Class<? extends TokenizerFactory>> getAvailableTokenizerFactories();
 
   /**
+   * Returns the corresponding SPI name for a TokenizerFactory class name.
+   * @param className - class name
+   * @return name of the tokenizer factory, or empty if the factory class is not found in the current context.
+   */
+  Optional<String> getTokenizerFactorySPIName(String className);
+
+  /**
    * Returns available {@link TokenFilterFactory}s.
    */
   Collection<Class<? extends TokenFilterFactory>> getAvailableTokenFilterFactories();
+
+  /**
+   * Returns the corresponding SPI name for a TokenFilterFactory class name.
+   * @param className - class name
+   * @return name of the token filter factory, or empty if the factory class is not found in the current context.
+   */
+  Optional<String> getTokenFilterFactorySPIName(String className);
 
   /**
    * Creates new Analyzer instance for the specified class name.

--- a/src/main/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/src/main/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -18,6 +18,8 @@
 package org.apache.lucene.luke.models.analysis;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import jdk.nashorn.internal.runtime.options.Option;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
@@ -34,6 +36,7 @@ import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.tools.jstat.Identifier;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -47,10 +50,13 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public final class AnalysisImpl implements Analysis {
@@ -58,6 +64,12 @@ public final class AnalysisImpl implements Analysis {
   private static final Logger logger = LoggerFactory.getLogger(AnalysisImpl.class);
 
   private final List<Class<? extends Analyzer>> presetAnalyzerTypes;
+
+  private Map<String, String> tokenizerSPINameMap = new HashMap<>();
+
+  private Map<String, String> charFilterSPINameMap = new HashMap<>();
+
+  private Map<String, String> tokenFilterSPINameMap = new HashMap<>();
 
   private Analyzer analyzer;
 
@@ -85,8 +97,6 @@ public final class AnalysisImpl implements Analysis {
       try {
         URL url = path.toUri().toURL();
         urls.add(url);
-        // add url to system class loader
-        addURLToSystemClassLoader(url);
       } catch (IOException e) {
         throw new LukeException(e.getMessage(), e);
       }
@@ -100,21 +110,6 @@ public final class AnalysisImpl implements Analysis {
     TokenFilterFactory.reloadTokenFilters(classLoader);
   }
 
-  private static final Class[] parameters = new Class[]{URL.class};
-  private void addURLToSystemClassLoader(URL url) throws IOException {
-    URLClassLoader sysloader = (URLClassLoader) ClassLoader.getSystemClassLoader();
-    Class sysclass = URLClassLoader.class;
-
-    try {
-      Method method = sysclass.getDeclaredMethod("addURL", parameters);
-      method.setAccessible(true);
-      method.invoke(sysloader, url);
-    } catch (Throwable t) {
-      t.printStackTrace();
-      throw new IOException("Error, could not add URL to system classloader");
-    }
-  }
-
   @Override
   public Collection<Class<? extends Analyzer>> getPresetAnalyzerTypes() {
     return ImmutableList.copyOf(presetAnalyzerTypes);
@@ -122,26 +117,41 @@ public final class AnalysisImpl implements Analysis {
 
   @Override
   public Collection<Class<? extends CharFilterFactory>> getAvailableCharFilterFactories() {
-    return CharFilterFactory.availableCharFilters().stream()
-        .map(CharFilterFactory::lookupClass)
-        .sorted(Comparator.comparing(Class::getName))
-        .collect(Collectors.toList());
+    Map<Class<? extends CharFilterFactory>, String> nameMap = CharFilterFactory.availableCharFilters().stream()
+        .collect(Collectors.toMap(CharFilterFactory::lookupClass, Function.identity()));
+    charFilterSPINameMap = nameMap.keySet().stream().collect(Collectors.toMap(Class::getName, nameMap::get));
+    return nameMap.keySet().stream().sorted(Comparator.comparing(Class::getName)).collect(Collectors.toList());
+  }
+
+  @Override
+  public Optional<String> getCharFilterFactorySPIName(String className) {
+    return Optional.ofNullable(charFilterSPINameMap.get(className));
   }
 
   @Override
   public Collection<Class<? extends TokenizerFactory>> getAvailableTokenizerFactories() {
-    return TokenizerFactory.availableTokenizers().stream()
-        .map(TokenizerFactory::lookupClass)
-        .sorted(Comparator.comparing(Class::getName))
-        .collect(Collectors.toList());
+    Map<Class<? extends TokenizerFactory>, String> nameMap = TokenizerFactory.availableTokenizers().stream()
+        .collect(Collectors.toMap(TokenizerFactory::lookupClass, Function.identity()));
+    tokenizerSPINameMap = nameMap.keySet().stream().collect(Collectors.toMap(Class::getName, nameMap::get));
+    return nameMap.keySet().stream().sorted(Comparator.comparing(Class::getName)).collect(Collectors.toList());
+  }
+
+  @Override
+  public Optional<String> getTokenizerFactorySPIName(String className) {
+    return Optional.ofNullable(tokenizerSPINameMap.get(className));
   }
 
   @Override
   public Collection<Class<? extends TokenFilterFactory>> getAvailableTokenFilterFactories() {
-    return TokenFilterFactory.availableTokenFilters().stream()
-        .map(TokenFilterFactory::lookupClass)
-        .sorted(Comparator.comparing(Class::getName))
-        .collect(Collectors.toList());
+    Map<Class<? extends TokenFilterFactory>, String> nameMap = TokenFilterFactory.availableTokenFilters().stream()
+        .collect(Collectors.toMap(TokenFilterFactory::lookupClass, Function.identity()));
+    tokenFilterSPINameMap = nameMap.keySet().stream().collect(Collectors.toMap(Class::getName, nameMap::get));
+    return nameMap.keySet().stream().sorted(Comparator.comparing(Class::getName)).collect(Collectors.toList());
+  }
+
+  @Override
+  public Optional<String> getTokenFilterFactorySPIName(String className) {
+    return Optional.ofNullable(tokenFilterSPINameMap.get(className));
   }
 
   private <T> List<Class<? extends T>> getInstantiableSubTypesBuiltIn(Class<T> superType) {
@@ -215,17 +225,16 @@ public final class AnalysisImpl implements Analysis {
           .orElse(CustomAnalyzer.builder());
 
       // set tokenizer
-      builder.withTokenizer(Class.forName(config.getTokenizerConfig().getName()).asSubclass(TokenizerFactory.class),
-          config.getTokenizerConfig().getParams());
+      builder.withTokenizer(config.getTokenizerConfig().getName(), config.getTokenizerConfig().getParams());
 
       // add char filters
       for (CustomAnalyzerConfig.ComponentConfig cfConf : config.getCharFilterConfigs()) {
-        builder.addCharFilter(Class.forName(cfConf.getName()).asSubclass(CharFilterFactory.class), cfConf.getParams());
+        builder.addCharFilter(cfConf.getName(), cfConf.getParams());
       }
 
       // add token filters
       for (CustomAnalyzerConfig.ComponentConfig tfConf : config.getTokenFilterConfigs()) {
-        builder.addTokenFilter(Class.forName(tfConf.getName()).asSubclass(TokenFilterFactory.class), tfConf.getParams());
+        builder.addTokenFilter(tfConf.getName(), tfConf.getParams());
       }
 
       // build analyzer

--- a/src/main/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/src/main/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -18,8 +18,6 @@
 package org.apache.lucene.luke.models.analysis;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import jdk.nashorn.internal.runtime.options.Option;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
@@ -36,11 +34,9 @@ import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.tools.jstat.Identifier;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLClassLoader;

--- a/src/main/java/org/apache/lucene/luke/models/analysis/CustomAnalyzerConfig.java
+++ b/src/main/java/org/apache/lucene/luke/models/analysis/CustomAnalyzerConfig.java
@@ -46,8 +46,8 @@ public final class CustomAnalyzerConfig {
     private final List<ComponentConfig> charFilterConfigs = new ArrayList<>();
     private final List<ComponentConfig> tokenFilterConfigs = new ArrayList<>();
 
-    public Builder(@Nonnull String tokenizerName, @Nonnull Map<String, String> tokenizerParams) {
-      tokenizerConfig = new ComponentConfig(tokenizerName, new HashMap<>(tokenizerParams));
+    public Builder(@Nonnull String name, @Nonnull Map<String, String> tokenizerParams) {
+      tokenizerConfig = new ComponentConfig(name, new HashMap<>(tokenizerParams));
     }
 
     public Builder configDir(String val) {
@@ -107,7 +107,9 @@ public final class CustomAnalyzerConfig {
 
   static class ComponentConfig {
 
+    /* SPI name */
     private final String name;
+    /* parameter map */
     private final Map<String, String> params;
 
     ComponentConfig(@Nonnull String name, @Nonnull Map<String, String> params) {

--- a/src/test/java/org/apache/lucene/luke/models/analysis/AnalysisImplTest.java
+++ b/src/test/java/org/apache/lucene/luke/models/analysis/AnalysisImplTest.java
@@ -18,7 +18,6 @@
 package org.apache.lucene.luke.models.analysis;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.analysis.util.CharFilterFactory;
@@ -55,6 +54,13 @@ public class AnalysisImplTest extends AnalysisTestBase {
   }
 
   @Test
+  public void testGetCharFilterFactorySPIName() {
+    AnalysisImpl analysis = new AnalysisImpl();
+    analysis.getAvailableCharFilterFactories();
+    assertEquals("mapping", analysis.getCharFilterFactorySPIName("org.apache.lucene.analysis.charfilter.MappingCharFilterFactory").orElse(""));
+  }
+
+  @Test
   public void testGetAvailableTokenizerFactories() {
     AnalysisImpl analysis = new AnalysisImpl();
     Collection<Class<? extends TokenizerFactory>> tokenizerFactories = analysis.getAvailableTokenizerFactories();
@@ -62,10 +68,24 @@ public class AnalysisImplTest extends AnalysisTestBase {
   }
 
   @Test
+  public void testGetTokenizerFactorySPIName() {
+    AnalysisImpl analysis = new AnalysisImpl();
+    analysis.getAvailableTokenizerFactories();
+    assertEquals("keyword", analysis.getTokenizerFactorySPIName("org.apache.lucene.analysis.core.KeywordTokenizerFactory").orElse(""));
+  }
+
+  @Test
   public void testGetAvailableTokenFilterFactories() {
     AnalysisImpl analysis = new AnalysisImpl();
     Collection<Class<? extends TokenFilterFactory>> tokenFilterFactories = analysis.getAvailableTokenFilterFactories();
     assertNotNull(tokenFilterFactories);
+  }
+
+  @Test
+  public void testGetTokenFilterFactorySPIName() {
+    AnalysisImpl analysis = new AnalysisImpl();
+    analysis.getAvailableTokenFilterFactories();
+    assertEquals("lowercase", analysis.getTokenFilterFactorySPIName("org.apache.lucene.analysis.core.LowerCaseFilterFactory").orElse(""));
   }
 
   @Test
@@ -85,9 +105,9 @@ public class AnalysisImplTest extends AnalysisTestBase {
   public void testAnalyze_custom() throws Exception {
     AnalysisImpl analysis = new AnalysisImpl();
     CustomAnalyzerConfig.Builder builder = new CustomAnalyzerConfig.Builder(
-        "org.apache.lucene.analysis.core.KeywordTokenizerFactory",
+        "keyword",
         ImmutableMap.of("maxTokenLen", "128"))
-        .addTokenFilterConfig("org.apache.lucene.analysis.core.LowerCaseFilterFactory", Collections.emptyMap());
+        .addTokenFilterConfig("lowercase", Collections.emptyMap());
     CustomAnalyzer analyzer = (CustomAnalyzer) analysis.buildCustomAnalyzer(builder.build());
     assertEquals("org.apache.lucene.analysis.custom.CustomAnalyzer", analyzer.getClass().getName());
     assertEquals("org.apache.lucene.analysis.core.KeywordTokenizerFactory", analyzer.getTokenizerFactory().getClass().getName());
@@ -107,11 +127,11 @@ public class AnalysisImplTest extends AnalysisTestBase {
 
     AnalysisImpl analysis = new AnalysisImpl();
     CustomAnalyzerConfig.Builder builder = new CustomAnalyzerConfig.Builder(
-        "org.apache.lucene.analysis.core.WhitespaceTokenizerFactory",
+        "whitespace",
         ImmutableMap.of("maxTokenLen", "128"))
         .configDir(confDir.toString())
-        .addTokenFilterConfig("org.apache.lucene.analysis.core.LowerCaseFilterFactory", Collections.emptyMap())
-        .addTokenFilterConfig("org.apache.lucene.analysis.core.StopFilterFactory",
+        .addTokenFilterConfig("lowercase", Collections.emptyMap())
+        .addTokenFilterConfig("stop",
             ImmutableMap.of("ignoreCase", "true", "words", "stop.txt", "format", "wordset"));
     CustomAnalyzer analyzer = (CustomAnalyzer) analysis.buildCustomAnalyzer(builder.build());
     assertEquals("org.apache.lucene.analysis.custom.CustomAnalyzer", analyzer.getClass().getName());


### PR DESCRIPTION
This hack no longer works on JDK9+ (#138). Instead we can use factory SPI names here.