### PR TITLE
Convert the row index selected to the internal model's one.

### DIFF
--- a/src/main/java/org/apache/lucene/luke/app/desktop/components/OverviewPanelProvider.java
+++ b/src/main/java/org/apache/lucene/luke/app/desktop/components/OverviewPanelProvider.java
@@ -421,7 +421,10 @@ public final class OverviewPanelProvider implements Provider<JPanel> {
   }
 
   private String getSelectedField() {
-    int row = termCountsTable.getSelectedRow();
+    int selected = termCountsTable.getSelectedRow();
+    // need to convert selected row index to underlying model index
+    // https://docs.oracle.com/javase/8/docs/api/javax/swing/table/TableRowSorter.html
+    int row = termCountsTable.convertRowIndexToModel(selected);
     if (row < 0 || row >= termCountsTable.getRowCount()) {
       throw new IllegalStateException("Field is not selected.");
     }
@@ -526,7 +529,6 @@ public final class OverviewPanelProvider implements Provider<JPanel> {
     }
 
   }
-
 
 }
 


### PR DESCRIPTION
Fix for #153.

According to the TableRowSorter documentation, the selected index need to be converted to the internal model's index.
https://docs.oracle.com/javase/8/docs/api/javax/swing/table/TableRowSorter.html

