### PR TITLE
Upgrade lucene 7.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>luke</groupId>
     <artifactId>luke-swing</artifactId>
-    <version>7.6.0.1</version>
+    <version>7.7.0</version>
 
     <prerequisites>
         <maven>3.0</maven>
@@ -33,14 +33,14 @@
         <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--lucene.version>${project.version}</lucene.version-->
-        <lucene.version>7.6.0</lucene.version>
+        <lucene.version>7.7.0</lucene.version>
         <hadoop.version>2.7.2</hadoop.version>
         <log4j.version>2.11.0</log4j.version>
         <slf4j.version>1.7.7</slf4j.version>
         <guice.version>4.1.0</guice.version>
         <guava.version>14.0.1</guava.version>
         <reflections.version>0.9.5</reflections.version>
-        <junit.version>4.10</junit.version>
+        <junit.version>4.12</junit.version>
         <mockito.version>2.6.2</mockito.version>
         <findbugs.version>3.0.1</findbugs.version>
         <jgoodies.version>2.7.0</jgoodies.version>

--- a/src/main/java/org/apache/lucene/luke/app/desktop/components/SearchPanelProvider.java
+++ b/src/main/java/org/apache/lucene/luke/app/desktop/components/SearchPanelProvider.java
@@ -469,7 +469,6 @@ public final class SearchPanelProvider implements Provider<JPanel>, SearchTabOpe
     }
     parseBtn.setEnabled(false);
     rewriteCB.setEnabled(false);
-    mltBtn.setEnabled(false);
     mltDocFTF.setEnabled(false);
   }
 
@@ -479,7 +478,6 @@ public final class SearchPanelProvider implements Provider<JPanel>, SearchTabOpe
     tabbedPane.setEnabledAt(Tab.SIMILARITY.index(), true);
     parseBtn.setEnabled(true);
     rewriteCB.setEnabled(true);
-    mltBtn.setEnabled(true);
     mltDocFTF.setEnabled(true);
   }
 


### PR DESCRIPTION
There is no API changes in Lucene 7.7.0:
https://lucene.apache.org/core/7_7_0/changes/Changes.html

Only upgrading pom dependency is needed.